### PR TITLE
Roman numerals separate tests

### DIFF
--- a/bin/stub-check
+++ b/bin/stub-check
@@ -20,7 +20,7 @@ die () {
 # make sure we are in the right place
 #
 # special '##' syntax removes the prefix from $PWD
-if [[ elisp == ${PWD##*/} ]]; then
+if [[ emacs-lisp == ${PWD##*/} ]]; then
     # make life easier = less string parsing
     cd exercises
 else
@@ -28,7 +28,7 @@ else
     die "can't run 'stub-check' from ${PWD}."
 fi
 
-# loop the directory in 'elisp/exercises'
+# loop the directory in 'emacs-lisp/exercises'
 for exercise in *; do
     # verify the existence of the stub file
     if [[ -f "${exercise}/${exercise}.el" ]]; then

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -43,9 +43,9 @@ manager or build from source as appropriate.
 ### Windows
 So you've decided to install Emacs on Windows.
 
-[[http://www.zeldauniverse.net/wp-content/uploads/2012/01/83-Image-2.jpg]]
+![](http://www.zeldauniverse.net/wp-content/uploads/2012/01/83-Image-2.jpg)
 
 I've never done it, but the prevailing wisdom is that you just need to visit the
-[[http://ftp.wayne.edu/gnu/emacs/windows/][FTP archive]], grab the correct binary (=emacs-24.x-bin-xxx.zip=), unzip it and
-launch. YMMV, please let us know in the issues or [[https://gitter.im/exercism/support][on Gitter]] if this section
+[FTP archive](http://ftp.wayne.edu/gnu/emacs/windows/), grab the correct binary (=emacs-24.x-bin-xxx.zip=), unzip it and
+launch. YMMV, please let us know in the issues or [on Gitter](https://gitter.im/exercism/support) if this section
 needs some love.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -35,7 +35,7 @@ code.
 Since both your code and tests are valid elisp, it is suggested to work with
 your exercise code in a buffer pane side-by side with its test, like so:
 
-![](docs/img/dual-pane.png)
+![](/docs/img/dual-pane.png)
 
 Split the frame vertically with `C-x 3`, switch to the new window with `C-x o`,
 and open the file with `C-x C-f /path/to/file`.

--- a/exercises/roman-numerals/roman-numerals-test.el
+++ b/exercises/roman-numerals/roman-numerals-test.el
@@ -6,24 +6,58 @@
 
 (load-file "roman-numerals.el")
 
-(ert-deftest roman-numerals-test ()
-  (should (equal (to-roman 1) "I"))
-  (should (equal (to-roman 2) "II"))
-  (should (equal (to-roman 3) "III"))
-  (should (equal (to-roman 4) "IV"))
-  (should (equal (to-roman 5) "V"))
-  (should (equal (to-roman 6) "VI"))
-  (should (equal (to-roman 9) "IX"))
-  (should (equal (to-roman 27) "XXVII"))
-  (should (equal (to-roman 48) "XLVIII"))
-  (should (equal (to-roman 59) "LIX"))
-  (should (equal (to-roman 93) "XCIII"))
-  (should (equal (to-roman 141) "CXLI"))
-  (should (equal (to-roman 163) "CLXIII"))
-  (should (equal (to-roman 402) "CDII"))
-  (should (equal (to-roman 575) "DLXXV"))
-  (should (equal (to-roman 911) "CMXI"))
-  (should (equal (to-roman 1024) "MXXIV"))
+(ert-deftest to-roman-1 ()
+  (should (equal (to-roman 1) "I")))
+
+(ert-deftest to-roman-2 ()
+  (should (equal (to-roman 2) "II")))
+
+(ert-deftest to-roman-3 ()
+  (should (equal (to-roman 3) "III")))
+
+(ert-deftest to-roman-4 ()
+  (should (equal (to-roman 4) "IV")))
+
+(ert-deftest to-roman-5 ()
+  (should (equal (to-roman 5) "V")))
+
+(ert-deftest to-roman-6 ()
+  (should (equal (to-roman 6) "VI")))
+
+(ert-deftest to-roman-9 ()
+  (should (equal (to-roman 9) "IX")))
+
+(ert-deftest to-roman-27 ()
+  (should (equal (to-roman 27) "XXVII")))
+
+(ert-deftest to-roman-48 ()
+  (should (equal (to-roman 48) "XLVIII")))
+
+(ert-deftest to-roman-59 ()
+  (should (equal (to-roman 59) "LIX")))
+
+(ert-deftest to-roman-93 ()
+  (should (equal (to-roman 93) "XCIII")))
+
+(ert-deftest to-roman-141 ()
+  (should (equal (to-roman 141) "CXLI")))
+
+(ert-deftest to-roman-163 ()
+  (should (equal (to-roman 163) "CLXIII")))
+
+(ert-deftest to-roman-402 ()
+  (should (equal (to-roman 402) "CDII")))
+
+(ert-deftest to-roman-575 ()
+  (should (equal (to-roman 575) "DLXXV")))
+
+(ert-deftest to-roman-911 ()
+  (should (equal (to-roman 911) "CMXI")))
+
+(ert-deftest to-roman-1024 ()
+  (should (equal (to-roman 1024) "MXXIV")))
+
+(ert-deftest to-roman-3000 ()
   (should (equal (to-roman 3000) "MMM")))
 
 (provide 'roman-numerals)


### PR DESCRIPTION
A couple of things in this PR:
- few broken links (org-mode style instead of markdown)
- fix a screenshot link. There were already attempts to fix it in #111 and #116. See the bottom of [this](https://github.com/exercism/docs/blob/master/language-tracks/documentation/for-consumers.md) document for the right format
- and the last is about a test in roman-numerals. I'm not sure if there are any specific rules for this, but I find it more convenient to have separate test for each case