### PR TITLE
Bringing your track in line with the latest changes to Problem Specifications

### DIFF
--- a/exercises/practice/acronym/.meta/tests.toml
+++ b/exercises/practice/acronym/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[1e22cceb-c5e4-4562-9afe-aef07ad1eaf4]
+description = "basic"
+
+[79ae3889-a5c0-4b01-baf0-232d31180c08]
+description = "lowercase words"
+
+[ec7000a7-3931-4a17-890e-33ca2073a548]
+description = "punctuation"
+
+[32dd261c-0c92-469a-9c5c-b192e94a63b0]
+description = "all caps word"
+
+[ae2ac9fa-a606-4d05-8244-3bcc4659c1d4]
+description = "punctuation without whitespace"
+
+[0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9]
+description = "very long abbreviation"
+
+[6a078f49-c68d-4b7b-89af-33a1a98c28cc]
+description = "consecutive delimiters"
+
+[5118b4b1-4572-434c-8d57-5b762e57973e]
+description = "apostrophes"
+
+[adc12eab-ec2d-414f-b48c-66a4fc06cdef]
+description = "underscore emphasis"

--- a/exercises/practice/allergies/.meta/tests.toml
+++ b/exercises/practice/allergies/.meta/tests.toml
@@ -1,0 +1,157 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[17fc7296-2440-4ac4-ad7b-d07c321bc5a0]
+description = "testing for eggs allergy -> not allergic to anything"
+
+[07ced27b-1da5-4c2e-8ae2-cb2791437546]
+description = "testing for eggs allergy -> allergic only to eggs"
+
+[5035b954-b6fa-4b9b-a487-dae69d8c5f96]
+description = "testing for eggs allergy -> allergic to eggs and something else"
+
+[64a6a83a-5723-4b5b-a896-663307403310]
+description = "testing for eggs allergy -> allergic to something, but not eggs"
+
+[90c8f484-456b-41c4-82ba-2d08d93231c6]
+description = "testing for eggs allergy -> allergic to everything"
+
+[d266a59a-fccc-413b-ac53-d57cb1f0db9d]
+description = "testing for peanuts allergy -> not allergic to anything"
+
+[ea210a98-860d-46b2-a5bf-50d8995b3f2a]
+description = "testing for peanuts allergy -> allergic only to peanuts"
+
+[eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b]
+description = "testing for peanuts allergy -> allergic to peanuts and something else"
+
+[9152058c-ce39-4b16-9b1d-283ec6d25085]
+description = "testing for peanuts allergy -> allergic to something, but not peanuts"
+
+[d2d71fd8-63d5-40f9-a627-fbdaf88caeab]
+description = "testing for peanuts allergy -> allergic to everything"
+
+[b948b0a1-cbf7-4b28-a244-73ff56687c80]
+description = "testing for shellfish allergy -> not allergic to anything"
+
+[9ce9a6f3-53e9-4923-85e0-73019047c567]
+description = "testing for shellfish allergy -> allergic only to shellfish"
+
+[b272fca5-57ba-4b00-bd0c-43a737ab2131]
+description = "testing for shellfish allergy -> allergic to shellfish and something else"
+
+[21ef8e17-c227-494e-8e78-470a1c59c3d8]
+description = "testing for shellfish allergy -> allergic to something, but not shellfish"
+
+[cc789c19-2b5e-4c67-b146-625dc8cfa34e]
+description = "testing for shellfish allergy -> allergic to everything"
+
+[651bde0a-2a74-46c4-ab55-02a0906ca2f5]
+description = "testing for strawberries allergy -> not allergic to anything"
+
+[b649a750-9703-4f5f-b7f7-91da2c160ece]
+description = "testing for strawberries allergy -> allergic only to strawberries"
+
+[50f5f8f3-3bac-47e6-8dba-2d94470a4bc6]
+description = "testing for strawberries allergy -> allergic to strawberries and something else"
+
+[23dd6952-88c9-48d7-a7d5-5d0343deb18d]
+description = "testing for strawberries allergy -> allergic to something, but not strawberries"
+
+[74afaae2-13b6-43a2-837a-286cd42e7d7e]
+description = "testing for strawberries allergy -> allergic to everything"
+
+[c49a91ef-6252-415e-907e-a9d26ef61723]
+description = "testing for tomatoes allergy -> not allergic to anything"
+
+[b69c5131-b7d0-41ad-a32c-e1b2cc632df8]
+description = "testing for tomatoes allergy -> allergic only to tomatoes"
+
+[1ca50eb1-f042-4ccf-9050-341521b929ec]
+description = "testing for tomatoes allergy -> allergic to tomatoes and something else"
+
+[e9846baa-456b-4eff-8025-034b9f77bd8e]
+description = "testing for tomatoes allergy -> allergic to something, but not tomatoes"
+
+[b2414f01-f3ad-4965-8391-e65f54dad35f]
+description = "testing for tomatoes allergy -> allergic to everything"
+
+[978467ab-bda4-49f7-b004-1d011ead947c]
+description = "testing for chocolate allergy -> not allergic to anything"
+
+[59cf4e49-06ea-4139-a2c1-d7aad28f8cbc]
+description = "testing for chocolate allergy -> allergic only to chocolate"
+
+[b0a7c07b-2db7-4f73-a180-565e07040ef1]
+description = "testing for chocolate allergy -> allergic to chocolate and something else"
+
+[f5506893-f1ae-482a-b516-7532ba5ca9d2]
+description = "testing for chocolate allergy -> allergic to something, but not chocolate"
+
+[02debb3d-d7e2-4376-a26b-3c974b6595c6]
+description = "testing for chocolate allergy -> allergic to everything"
+
+[17f4a42b-c91e-41b8-8a76-4797886c2d96]
+description = "testing for pollen allergy -> not allergic to anything"
+
+[7696eba7-1837-4488-882a-14b7b4e3e399]
+description = "testing for pollen allergy -> allergic only to pollen"
+
+[9a49aec5-fa1f-405d-889e-4dfc420db2b6]
+description = "testing for pollen allergy -> allergic to pollen and something else"
+
+[3cb8e79f-d108-4712-b620-aa146b1954a9]
+description = "testing for pollen allergy -> allergic to something, but not pollen"
+
+[1dc3fe57-7c68-4043-9d51-5457128744b2]
+description = "testing for pollen allergy -> allergic to everything"
+
+[d3f523d6-3d50-419b-a222-d4dfd62ce314]
+description = "testing for cats allergy -> not allergic to anything"
+
+[eba541c3-c886-42d3-baef-c048cb7fcd8f]
+description = "testing for cats allergy -> allergic only to cats"
+
+[ba718376-26e0-40b7-bbbe-060287637ea5]
+description = "testing for cats allergy -> allergic to cats and something else"
+
+[3c6dbf4a-5277-436f-8b88-15a206f2d6c4]
+description = "testing for cats allergy -> allergic to something, but not cats"
+
+[1faabb05-2b98-4995-9046-d83e4a48a7c1]
+description = "testing for cats allergy -> allergic to everything"
+
+[f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f]
+description = "list when: -> no allergies"
+
+[9e1a4364-09a6-4d94-990f-541a94a4c1e8]
+description = "list when: -> just eggs"
+
+[8851c973-805e-4283-9e01-d0c0da0e4695]
+description = "list when: -> just peanuts"
+
+[2c8943cb-005e-435f-ae11-3e8fb558ea98]
+description = "list when: -> just strawberries"
+
+[6fa95d26-044c-48a9-8a7b-9ee46ec32c5c]
+description = "list when: -> eggs and peanuts"
+
+[19890e22-f63f-4c5c-a9fb-fb6eacddfe8e]
+description = "list when: -> more than eggs but not peanuts"
+
+[4b68f470-067c-44e4-889f-c9fe28917d2f]
+description = "list when: -> lots of stuff"
+
+[0881b7c5-9efa-4530-91bd-68370d054bc7]
+description = "list when: -> everything"
+
+[12ce86de-b347-42a0-ab7c-2e0570f0c65b]
+description = "list when: -> no allergen score parts"

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -1,0 +1,56 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[dd40c4d2-3c8b-44e5-992a-f42b393ec373]
+description = "no matches"
+
+[b3cca662-f50a-489e-ae10-ab8290a09bdc]
+description = "detects two anagrams"
+
+[03eb9bbe-8906-4ea0-84fa-ffe711b52c8b]
+description = "detects two anagrams"
+reimplements = "b3cca662-f50a-489e-ae10-ab8290a09bdc"
+
+[a27558ee-9ba0-4552-96b1-ecf665b06556]
+description = "does not detect anagram subsets"
+
+[64cd4584-fc15-4781-b633-3d814c4941a4]
+description = "detects anagram"
+
+[99c91beb-838f-4ccd-b123-935139917283]
+description = "detects three anagrams"
+
+[78487770-e258-4e1f-a646-8ece10950d90]
+description = "detects multiple anagrams with different case"
+
+[1d0ab8aa-362f-49b7-9902-3d0c668d557b]
+description = "does not detect non-anagrams with identical checksum"
+
+[9e632c0b-c0b1-4804-8cc1-e295dea6d8a8]
+description = "detects anagrams case-insensitively"
+
+[b248e49f-0905-48d2-9c8d-bd02d8c3e392]
+description = "detects anagrams using case-insensitive subject"
+
+[f367325c-78ec-411c-be76-e79047f4bd54]
+description = "detects anagrams using case-insensitive possible matches"
+
+[7cc195ad-e3c7-44ee-9fd2-d3c344806a2c]
+description = "does not detect an anagram if the original word is repeated"
+
+[9878a1c9-d6ea-4235-ae51-3ea2befd6842]
+description = "anagrams must use all letters exactly once"
+
+[85757361-4535-45fd-ac0e-3810d40debc1]
+description = "words are not anagrams of themselves (case-insensitive)"
+
+[a0705568-628c-4b55-9798-82e4acde51ca]
+description = "words other than themselves can be anagrams"

--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[c1ed103c-258d-45b2-be73-d8c6d9580c7b]
+description = "Zero is an Armstrong number"
+
+[579e8f03-9659-4b85-a1a2-d64350f6b17a]
+description = "Single digit numbers are Armstrong numbers"
+
+[2d6db9dc-5bf8-4976-a90b-b2c2b9feba60]
+description = "There are no 2 digit Armstrong numbers"
+
+[509c087f-e327-4113-a7d2-26a4e9d18283]
+description = "Three digit number that is an Armstrong number"
+
+[7154547d-c2ce-468d-b214-4cb953b870cf]
+description = "Three digit number that is not an Armstrong number"
+
+[6bac5b7b-42e9-4ecb-a8b0-4832229aa103]
+description = "Four digit number that is an Armstrong number"
+
+[eed4b331-af80-45b5-a80b-19c9ea444b2e]
+description = "Four digit number that is not an Armstrong number"
+
+[f971ced7-8d68-4758-aea1-d4194900b864]
+description = "Seven digit number that is an Armstrong number"
+
+[7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18]
+description = "Seven digit number that is not an Armstrong number"

--- a/exercises/practice/atbash-cipher/.meta/tests.toml
+++ b/exercises/practice/atbash-cipher/.meta/tests.toml
@@ -1,0 +1,52 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[2f47ebe1-eab9-4d6b-b3c6-627562a31c77]
+description = "encode -> encode yes"
+
+[b4ffe781-ea81-4b74-b268-cc58ba21c739]
+description = "encode -> encode no"
+
+[10e48927-24ab-4c4d-9d3f-3067724ace00]
+description = "encode -> encode OMG"
+
+[d59b8bc3-509a-4a9a-834c-6f501b98750b]
+description = "encode -> encode spaces"
+
+[31d44b11-81b7-4a94-8b43-4af6a2449429]
+description = "encode -> encode mindblowingly"
+
+[d503361a-1433-48c0-aae0-d41b5baa33ff]
+description = "encode -> encode numbers"
+
+[79c8a2d5-0772-42d4-b41b-531d0b5da926]
+description = "encode -> encode deep thought"
+
+[9ca13d23-d32a-4967-a1fd-6100b8742bab]
+description = "encode -> encode all the letters"
+
+[bb50e087-7fdf-48e7-9223-284fe7e69851]
+description = "decode -> decode exercism"
+
+[ac021097-cd5d-4717-8907-b0814b9e292c]
+description = "decode -> decode a sentence"
+
+[18729de3-de74-49b8-b68c-025eaf77f851]
+description = "decode -> decode numbers"
+
+[0f30325f-f53b-415d-ad3e-a7a4f63de034]
+description = "decode -> decode all the letters"
+
+[39640287-30c6-4c8c-9bac-9d613d1a5674]
+description = "decode -> decode with too many spaces"
+
+[b34edf13-34c0-49b5-aa21-0768928000d5]
+description = "decode -> decode with no spaces"

--- a/exercises/practice/binary/.meta/tests.toml
+++ b/exercises/practice/binary/.meta/tests.toml
@@ -1,0 +1,55 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[567fc71e-1013-4915-9285-bca0648c0844]
+description = "binary 0 is decimal 0"
+
+[c0824fb1-6a0a-4e9a-a262-c6c00af99fa8]
+description = "binary 1 is decimal 1"
+
+[4d2834fb-3cc3-4159-a8fd-da1098def8ed]
+description = "binary 10 is decimal 2"
+
+[b7b2b649-4a7c-4808-9eb9-caf00529bac6]
+description = "binary 11 is decimal 3"
+
+[de761aff-73cd-43c1-9e1f-0417f07b1e4a]
+description = "binary 100 is decimal 4"
+
+[7849a8f7-f4a1-4966-963e-503282d6814c]
+description = "binary 1001 is decimal 9"
+
+[836a101c-aecb-473b-ba78-962408dcda98]
+description = "binary 11010 is decimal 26"
+
+[1c6822a4-8584-438b-8dd4-40f0f0b66371]
+description = "binary 10001101000 is decimal 1128"
+
+[91ffe632-8374-4016-b1d1-d8400d9f940d]
+description = "binary ignores leading zeros"
+
+[44f7d8b1-ddc3-4751-8be3-700a538b421c]
+description = "2 is not a valid binary digit"
+
+[c263a24d-6870-420f-b783-628feefd7b6e]
+description = "a number containing a non-binary digit is invalid"
+
+[8d81305b-0502-4a07-bfba-051c5526d7f2]
+description = "a number with trailing non-binary characters is invalid"
+
+[a7f79b6b-039a-4d42-99b4-fcee56679f03]
+description = "a number with leading non-binary characters is invalid"
+
+[9e0ece9d-b8aa-46a0-a22b-3bed2e3f741e]
+description = "a number with internal non-binary characters is invalid"
+
+[46c8dd65-0c32-4273-bb0d-f2b111bccfbd]
+description = "a number and a word whitespace separated is invalid"

--- a/exercises/practice/bob/.meta/tests.toml
+++ b/exercises/practice/bob/.meta/tests.toml
@@ -1,0 +1,85 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[e162fead-606f-437a-a166-d051915cea8e]
+description = "stating something"
+
+[73a966dc-8017-47d6-bb32-cf07d1a5fcd9]
+description = "shouting"
+
+[d6c98afd-df35-4806-b55e-2c457c3ab748]
+description = "shouting gibberish"
+
+[8a2e771d-d6f1-4e3f-b6c6-b41495556e37]
+description = "asking a question"
+
+[81080c62-4e4d-4066-b30a-48d8d76920d9]
+description = "asking a numeric question"
+
+[2a02716d-685b-4e2e-a804-2adaf281c01e]
+description = "asking gibberish"
+
+[c02f9179-ab16-4aa7-a8dc-940145c385f7]
+description = "talking forcefully"
+
+[153c0e25-9bb5-4ec5-966e-598463658bcd]
+description = "using acronyms in regular speech"
+
+[a5193c61-4a92-4f68-93e2-f554eb385ec6]
+description = "forceful question"
+
+[a20e0c54-2224-4dde-8b10-bd2cdd4f61bc]
+description = "shouting numbers"
+
+[f7bc4b92-bdff-421e-a238-ae97f230ccac]
+description = "no letters"
+
+[bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2]
+description = "question with no letters"
+
+[496143c8-1c31-4c01-8a08-88427af85c66]
+description = "shouting with special characters"
+
+[e6793c1c-43bd-4b8d-bc11-499aea73925f]
+description = "shouting with no exclamation mark"
+
+[aa8097cc-c548-4951-8856-14a404dd236a]
+description = "statement containing question mark"
+
+[9bfc677d-ea3a-45f2-be44-35bc8fa3753e]
+description = "non-letters with question"
+
+[8608c508-f7de-4b17-985b-811878b3cf45]
+description = "prattling on"
+
+[bc39f7c6-f543-41be-9a43-fd1c2f753fc0]
+description = "silence"
+
+[d6c47565-372b-4b09-b1dd-c40552b8378b]
+description = "prolonged silence"
+
+[4428f28d-4100-4d85-a902-e5a78cb0ecd3]
+description = "alternate silence"
+
+[66953780-165b-4e7e-8ce3-4bcb80b6385a]
+description = "multiple line question"
+
+[5371ef75-d9ea-4103-bcfa-2da973ddec1b]
+description = "starting with whitespace"
+
+[05b304d6-f83b-46e7-81e0-4cd3ca647900]
+description = "ending with whitespace"
+
+[72bd5ad3-9b2f-4931-a988-dce1f5771de2]
+description = "other whitespace"
+
+[12983553-8601-46a8-92fa-fcaa3bc4a2a0]
+description = "non-question ending with whitespace"

--- a/exercises/practice/crypto-square/.meta/tests.toml
+++ b/exercises/practice/crypto-square/.meta/tests.toml
@@ -1,0 +1,31 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[407c3837-9aa7-4111-ab63-ec54b58e8e9f]
+description = "empty plaintext results in an empty ciphertext"
+
+[64131d65-6fd9-4f58-bdd8-4a2370fb481d]
+description = "Lowercase"
+
+[63a4b0ed-1e3c-41ea-a999-f6f26ba447d6]
+description = "Remove spaces"
+
+[1b5348a1-7893-44c1-8197-42d48d18756c]
+description = "Remove punctuation"
+
+[8574a1d3-4a08-4cec-a7c7-de93a164f41a]
+description = "9 character plaintext results in 3 chunks of 3 characters"
+
+[a65d3fa1-9e09-43f9-bcec-7a672aec3eae]
+description = "8 character plaintext results in 3 chunks, the last one with a trailing space"
+
+[fbcb0c6d-4c39-4a31-83f6-c473baa6af80]
+description = "54 character plaintext results in 7 chunks, the last two with trailing spaces"

--- a/exercises/practice/difference-of-squares/.meta/tests.toml
+++ b/exercises/practice/difference-of-squares/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[e46c542b-31fc-4506-bcae-6b62b3268537]
+description = "Square the sum of the numbers up to the given number -> square of sum 1"
+
+[9b3f96cb-638d-41ee-99b7-b4f9c0622948]
+description = "Square the sum of the numbers up to the given number -> square of sum 5"
+
+[54ba043f-3c35-4d43-86ff-3a41625d5e86]
+description = "Square the sum of the numbers up to the given number -> square of sum 100"
+
+[01d84507-b03e-4238-9395-dd61d03074b5]
+description = "Sum the squares of the numbers up to the given number -> sum of squares 1"
+
+[c93900cd-8cc2-4ca4-917b-dd3027023499]
+description = "Sum the squares of the numbers up to the given number -> sum of squares 5"
+
+[94807386-73e4-4d9e-8dec-69eb135b19e4]
+description = "Sum the squares of the numbers up to the given number -> sum of squares 100"
+
+[44f72ae6-31a7-437f-858d-2c0837adabb6]
+description = "Subtract sum of squares from square of sums -> difference of squares 1"
+
+[005cb2bf-a0c8-46f3-ae25-924029f8b00b]
+description = "Subtract sum of squares from square of sums -> difference of squares 5"
+
+[b1bf19de-9a16-41c0-a62b-1f02ecc0b036]
+description = "Subtract sum of squares from square of sums -> difference of squares 100"

--- a/exercises/practice/etl/.meta/tests.toml
+++ b/exercises/practice/etl/.meta/tests.toml
@@ -1,0 +1,22 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[78a7a9f9-4490-4a47-8ee9-5a38bb47d28f]
+description = "single letter"
+
+[60dbd000-451d-44c7-bdbb-97c73ac1f497]
+description = "single score with multiple letters"
+
+[f5c5de0c-301f-4fdd-a0e5-df97d4214f54]
+description = "multiple scores with multiple letters"
+
+[5db8ea89-ecb4-4dcd-902f-2b418cc87b9d]
+description = "multiple scores with differing numbers of letters"

--- a/exercises/practice/gigasecond/.meta/tests.toml
+++ b/exercises/practice/gigasecond/.meta/tests.toml
@@ -1,0 +1,25 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[92fbe71c-ea52-4fac-bd77-be38023cacf7]
+description = "date only specification of time"
+
+[6d86dd16-6f7a-47be-9e58-bb9fb2ae1433]
+description = "second test for date only specification of time"
+
+[77eb8502-2bca-4d92-89d9-7b39ace28dd5]
+description = "third test for date only specification of time"
+
+[c9d89a7d-06f8-4e28-a305-64f1b2abc693]
+description = "full time specified"
+
+[09d4e30e-728a-4b52-9005-be44a58d9eba]
+description = "full time with day roll-over"

--- a/exercises/practice/grains/.meta/tests.toml
+++ b/exercises/practice/grains/.meta/tests.toml
@@ -1,0 +1,43 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[9fbde8de-36b2-49de-baf2-cd42d6f28405]
+description = "returns the number of grains on the square -> grains on square 1"
+
+[ee1f30c2-01d8-4298-b25d-c677331b5e6d]
+description = "returns the number of grains on the square -> grains on square 2"
+
+[10f45584-2fc3-4875-8ec6-666065d1163b]
+description = "returns the number of grains on the square -> grains on square 3"
+
+[a7cbe01b-36f4-4601-b053-c5f6ae055170]
+description = "returns the number of grains on the square -> grains on square 4"
+
+[c50acc89-8535-44e4-918f-b848ad2817d4]
+description = "returns the number of grains on the square -> grains on square 16"
+
+[acd81b46-c2ad-4951-b848-80d15ed5a04f]
+description = "returns the number of grains on the square -> grains on square 32"
+
+[c73b470a-5efb-4d53-9ac6-c5f6487f227b]
+description = "returns the number of grains on the square -> grains on square 64"
+
+[1d47d832-3e85-4974-9466-5bd35af484e3]
+description = "returns the number of grains on the square -> square 0 raises an exception"
+
+[61974483-eeb2-465e-be54-ca5dde366453]
+description = "returns the number of grains on the square -> negative square raises an exception"
+
+[a95e4374-f32c-45a7-a10d-ffec475c012f]
+description = "returns the number of grains on the square -> square greater than 64 raises an exception"
+
+[6eb07385-3659-4b45-a6be-9dc474222750]
+description = "returns the total number of grains on the board"

--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -1,0 +1,61 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[f6dcb64f-03b0-4b60-81b1-3c9dbf47e887]
+description = "empty strands"
+
+[54681314-eee2-439a-9db0-b0636c656156]
+description = "single letter identical strands"
+
+[294479a3-a4c8-478f-8d63-6209815a827b]
+description = "single letter different strands"
+
+[9aed5f34-5693-4344-9b31-40c692fb5592]
+description = "long identical strands"
+
+[cd2273a5-c576-46c8-a52b-dee251c3e6e5]
+description = "long different strands"
+
+[919f8ef0-b767-4d1b-8516-6379d07fcb28]
+description = "disallow first strand longer"
+
+[b9228bb1-465f-4141-b40f-1f99812de5a8]
+description = "disallow first strand longer"
+reimplements = "919f8ef0-b767-4d1b-8516-6379d07fcb28"
+
+[8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
+description = "disallow second strand longer"
+
+[dab38838-26bb-4fff-acbe-3b0a9bfeba2d]
+description = "disallow second strand longer"
+reimplements = "8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e"
+
+[5dce058b-28d4-4ca7-aa64-adfe4e17784c]
+description = "disallow left empty strand"
+
+[db92e77e-7c72-499d-8fe6-9354d2bfd504]
+description = "disallow left empty strand"
+reimplements = "5dce058b-28d4-4ca7-aa64-adfe4e17784c"
+
+[b764d47c-83ff-4de2-ab10-6cfe4b15c0f3]
+description = "disallow empty first strand"
+reimplements = "db92e77e-7c72-499d-8fe6-9354d2bfd504"
+
+[38826d4b-16fb-4639-ac3e-ba027dec8b5f]
+description = "disallow right empty strand"
+
+[920cd6e3-18f4-4143-b6b8-74270bb8f8a3]
+description = "disallow right empty strand"
+reimplements = "38826d4b-16fb-4639-ac3e-ba027dec8b5f"
+
+[9ab9262f-3521-4191-81f5-0ed184a5aa89]
+description = "disallow empty second strand"
+reimplements = "920cd6e3-18f4-4143-b6b8-74270bb8f8a3"

--- a/exercises/practice/hello-world/.meta/tests.toml
+++ b/exercises/practice/hello-world/.meta/tests.toml
@@ -1,0 +1,13 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[af9ffe10-dc13-42d8-a742-e7bdafac449d]
+description = "Say Hi!"

--- a/exercises/practice/leap/.meta/tests.toml
+++ b/exercises/practice/leap/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[6466b30d-519c-438e-935d-388224ab5223]
+description = "year not divisible by 4 in common year"
+
+[ac227e82-ee82-4a09-9eb6-4f84331ffdb0]
+description = "year divisible by 2, not divisible by 4 in common year"
+
+[4fe9b84c-8e65-489e-970b-856d60b8b78e]
+description = "year divisible by 4, not divisible by 100 in leap year"
+
+[7fc6aed7-e63c-48f5-ae05-5fe182f60a5d]
+description = "year divisible by 4 and 5 is still a leap year"
+
+[78a7848f-9667-4192-ae53-87b30c9a02dd]
+description = "year divisible by 100, not divisible by 400 in common year"
+
+[9d70f938-537c-40a6-ba19-f50739ce8bac]
+description = "year divisible by 100 but not by 3 is still not a leap year"
+
+[42ee56ad-d3e6-48f1-8e3f-c84078d916fc]
+description = "year divisible by 400 is leap year"
+
+[57902c77-6fe9-40de-8302-587b5c27121e]
+description = "year divisible by 400 but not by 125 is still a leap year"
+
+[c30331f6-f9f6-4881-ad38-8ca8c12520c1]
+description = "year divisible by 200, not divisible by 400 in common year"

--- a/exercises/practice/luhn/.meta/tests.toml
+++ b/exercises/practice/luhn/.meta/tests.toml
@@ -1,0 +1,67 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[792a7082-feb7-48c7-b88b-bbfec160865e]
+description = "single digit strings can not be valid"
+
+[698a7924-64d4-4d89-8daa-32e1aadc271e]
+description = "a single zero is invalid"
+
+[73c2f62b-9b10-4c9f-9a04-83cee7367965]
+description = "a simple valid SIN that remains valid if reversed"
+
+[9369092e-b095-439f-948d-498bd076be11]
+description = "a simple valid SIN that becomes invalid if reversed"
+
+[8f9f2350-1faf-4008-ba84-85cbb93ffeca]
+description = "a valid Canadian SIN"
+
+[1cdcf269-6560-44fc-91f6-5819a7548737]
+description = "invalid Canadian SIN"
+
+[656c48c1-34e8-4e60-9a5a-aad8a367810a]
+description = "invalid credit card"
+
+[20e67fad-2121-43ed-99a8-14b5b856adb9]
+description = "invalid long number with an even remainder"
+
+[ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa]
+description = "valid number with an even number of digits"
+
+[ef081c06-a41f-4761-8492-385e13c8202d]
+description = "valid number with an odd number of spaces"
+
+[bef66f64-6100-4cbb-8f94-4c9713c5e5b2]
+description = "valid strings with a non-digit added at the end become invalid"
+
+[2177e225-9ce7-40f6-b55d-fa420e62938e]
+description = "valid strings with punctuation included become invalid"
+
+[ebf04f27-9698-45e1-9afe-7e0851d0fe8d]
+description = "valid strings with symbols included become invalid"
+
+[08195c5e-ce7f-422c-a5eb-3e45fece68ba]
+description = "single zero with space is invalid"
+
+[12e63a3c-f866-4a79-8c14-b359fc386091]
+description = "more than a single zero is valid"
+
+[ab56fa80-5de8-4735-8a4a-14dae588663e]
+description = "input digit 9 is correctly converted to output digit 9"
+
+[39a06a5a-5bad-4e0f-b215-b042d46209b1]
+description = "using ascii value for non-doubled non-digit isn't allowed"
+
+[f94cf191-a62f-4868-bc72-7253114aa157]
+description = "using ascii value for doubled non-digit isn't allowed"
+
+[8b72ad26-c8be-49a2-b99c-bcc3bf631b33]
+description = "non-numeric, non-space char in the middle with a sum that's divisible by 10 isn't allowed"

--- a/exercises/practice/nucleotide-count/.meta/tests.toml
+++ b/exercises/practice/nucleotide-count/.meta/tests.toml
@@ -1,0 +1,25 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[3e5c30a8-87e2-4845-a815-a49671ade970]
+description = "empty strand"
+
+[a0ea42a6-06d9-4ac6-828c-7ccaccf98fec]
+description = "can count one nucleotide in single-character input"
+
+[eca0d565-ed8c-43e7-9033-6cefbf5115b5]
+description = "strand with repeated nucleotide"
+
+[40a45eac-c83f-4740-901a-20b22d15a39f]
+description = "strand with multiple nucleotides"
+
+[b4c47851-ee9e-4b0a-be70-a86e343bd851]
+description = "strand with invalid nucleotides"

--- a/exercises/practice/pangram/.meta/tests.toml
+++ b/exercises/practice/pangram/.meta/tests.toml
@@ -1,0 +1,40 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[64f61791-508e-4f5c-83ab-05de042b0149]
+description = "empty sentence"
+
+[74858f80-4a4d-478b-8a5e-c6477e4e4e84]
+description = "perfect lower case"
+
+[61288860-35ca-4abe-ba08-f5df76ecbdcd]
+description = "only lower case"
+
+[6564267d-8ac5-4d29-baf2-e7d2e304a743]
+description = "missing the letter 'x'"
+
+[c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0]
+description = "missing the letter 'h'"
+
+[d835ec38-bc8f-48e4-9e36-eb232427b1df]
+description = "with underscores"
+
+[8cc1e080-a178-4494-b4b3-06982c9be2a8]
+description = "with numbers"
+
+[bed96b1c-ff95-45b8-9731-fdbdcb6ede9a]
+description = "missing letters replaced by numbers"
+
+[938bd5d8-ade5-40e2-a2d9-55a338a01030]
+description = "mixed case and punctuation"
+
+[2577bf54-83c8-402d-a64b-a2c0f7bb213a]
+description = "case insensitive"

--- a/exercises/practice/perfect-numbers/.meta/tests.toml
+++ b/exercises/practice/perfect-numbers/.meta/tests.toml
@@ -1,0 +1,49 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[163e8e86-7bfd-4ee2-bd68-d083dc3381a3]
+description = "Perfect numbers -> Smallest perfect number is classified correctly"
+
+[169a7854-0431-4ae0-9815-c3b6d967436d]
+description = "Perfect numbers -> Medium perfect number is classified correctly"
+
+[ee3627c4-7b36-4245-ba7c-8727d585f402]
+description = "Perfect numbers -> Large perfect number is classified correctly"
+
+[80ef7cf8-9ea8-49b9-8b2d-d9cb3db3ed7e]
+description = "Abundant numbers -> Smallest abundant number is classified correctly"
+
+[3e300e0d-1a12-4f11-8c48-d1027165ab60]
+description = "Abundant numbers -> Medium abundant number is classified correctly"
+
+[ec7792e6-8786-449c-b005-ce6dd89a772b]
+description = "Abundant numbers -> Large abundant number is classified correctly"
+
+[e610fdc7-2b6e-43c3-a51c-b70fb37413ba]
+description = "Deficient numbers -> Smallest prime deficient number is classified correctly"
+
+[0beb7f66-753a-443f-8075-ad7fbd9018f3]
+description = "Deficient numbers -> Smallest non-prime deficient number is classified correctly"
+
+[1c802e45-b4c6-4962-93d7-1cad245821ef]
+description = "Deficient numbers -> Medium deficient number is classified correctly"
+
+[47dd569f-9e5a-4a11-9a47-a4e91c8c28aa]
+description = "Deficient numbers -> Large deficient number is classified correctly"
+
+[a696dec8-6147-4d68-afad-d38de5476a56]
+description = "Deficient numbers -> Edge case (no factors other than itself) is classified correctly"
+
+[72445cee-660c-4d75-8506-6c40089dc302]
+description = "Invalid inputs -> Zero is rejected (as it is not a positive integer)"
+
+[2d72ce2c-6802-49ac-8ece-c790ba3dae13]
+description = "Invalid inputs -> Negative integer is rejected (as it is not a positive integer)"

--- a/exercises/practice/phone-number/.meta/tests.toml
+++ b/exercises/practice/phone-number/.meta/tests.toml
@@ -1,0 +1,64 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[79666dce-e0f1-46de-95a1-563802913c35]
+description = "cleans the number"
+
+[c360451f-549f-43e4-8aba-fdf6cb0bf83f]
+description = "cleans numbers with dots"
+
+[08f94c34-9a37-46a2-a123-2a8e9727395d]
+description = "cleans numbers with multiple spaces"
+
+[598d8432-0659-4019-a78b-1c6a73691d21]
+description = "invalid when 9 digits"
+
+[57061c72-07b5-431f-9766-d97da7c4399d]
+description = "invalid when 11 digits does not start with a 1"
+
+[9962cbf3-97bb-4118-ba9b-38ff49c64430]
+description = "valid when 11 digits and starting with 1"
+
+[fa724fbf-054c-4d91-95da-f65ab5b6dbca]
+description = "valid when 11 digits and starting with 1 even with punctuation"
+
+[c6a5f007-895a-4fc5-90bc-a7e70f9b5cad]
+description = "invalid when more than 11 digits"
+
+[63f38f37-53f6-4a5f-bd86-e9b404f10a60]
+description = "invalid with letters"
+
+[4bd97d90-52fd-45d3-b0db-06ab95b1244e]
+description = "invalid with punctuations"
+
+[d77d07f8-873c-4b17-8978-5f66139bf7d7]
+description = "invalid if area code starts with 0"
+
+[c7485cfb-1e7b-4081-8e96-8cdb3b77f15e]
+description = "invalid if area code starts with 1"
+
+[4d622293-6976-413d-b8bf-dd8a94d4e2ac]
+description = "invalid if exchange code starts with 0"
+
+[4cef57b4-7d8e-43aa-8328-1e1b89001262]
+description = "invalid if exchange code starts with 1"
+
+[9925b09c-1a0d-4960-a197-5d163cbe308c]
+description = "invalid if area code starts with 0 on valid 11-digit number"
+
+[3f809d37-40f3-44b5-ad90-535838b1a816]
+description = "invalid if area code starts with 1 on valid 11-digit number"
+
+[e08e5532-d621-40d4-b0cc-96c159276b65]
+description = "invalid if exchange code starts with 0 on valid 11-digit number"
+
+[57b32f3d-696a-455c-8bf1-137b6d171cdf]
+description = "invalid if exchange code starts with 1 on valid 11-digit number"

--- a/exercises/practice/raindrops/.meta/tests.toml
+++ b/exercises/practice/raindrops/.meta/tests.toml
@@ -1,0 +1,64 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[1575d549-e502-46d4-a8e1-6b7bec6123d8]
+description = "the sound for 1 is 1"
+
+[1f51a9f9-4895-4539-b182-d7b0a5ab2913]
+description = "the sound for 3 is Pling"
+
+[2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0]
+description = "the sound for 5 is Plang"
+
+[d7e60daa-32ef-4c23-b688-2abff46c4806]
+description = "the sound for 7 is Plong"
+
+[6bb4947b-a724-430c-923f-f0dc3d62e56a]
+description = "the sound for 6 is Pling as it has a factor 3"
+
+[ce51e0e8-d9d4-446d-9949-96eac4458c2d]
+description = "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base"
+
+[0dd66175-e3e2-47fc-8750-d01739856671]
+description = "the sound for 9 is Pling as it has a factor 3"
+
+[022c44d3-2182-4471-95d7-c575af225c96]
+description = "the sound for 10 is Plang as it has a factor 5"
+
+[37ab74db-fed3-40ff-b7b9-04acdfea8edf]
+description = "the sound for 14 is Plong as it has a factor of 7"
+
+[31f92999-6afb-40ee-9aa4-6d15e3334d0f]
+description = "the sound for 15 is PlingPlang as it has factors 3 and 5"
+
+[ff9bb95d-6361-4602-be2c-653fe5239b54]
+description = "the sound for 21 is PlingPlong as it has factors 3 and 7"
+
+[d2e75317-b72e-40ab-8a64-6734a21dece1]
+description = "the sound for 25 is Plang as it has a factor 5"
+
+[a09c4c58-c662-4e32-97fe-f1501ef7125c]
+description = "the sound for 27 is Pling as it has a factor 3"
+
+[bdf061de-8564-4899-a843-14b48b722789]
+description = "the sound for 35 is PlangPlong as it has factors 5 and 7"
+
+[c4680bee-69ba-439d-99b5-70c5fd1a7a83]
+description = "the sound for 49 is Plong as it has a factor 7"
+
+[17f2bc9a-b65a-4d23-8ccd-266e8c271444]
+description = "the sound for 52 is 52"
+
+[e46677ed-ff1a-419f-a740-5c713d2830e4]
+description = "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7"
+
+[13c6837a-0fcd-4b86-a0eb-20572f7deb0b]
+description = "the sound for 3125 is Plang as it has a factor 5"

--- a/exercises/practice/rna-transcription/.meta/tests.toml
+++ b/exercises/practice/rna-transcription/.meta/tests.toml
@@ -1,0 +1,28 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[b4631f82-c98c-4a2f-90b3-c5c2b6c6f661]
+description = "Empty RNA sequence"
+
+[a9558a3c-318c-4240-9256-5d5ed47005a6]
+description = "RNA complement of cytosine is guanine"
+
+[6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7]
+description = "RNA complement of guanine is cytosine"
+
+[870bd3ec-8487-471d-8d9a-a25046488d3e]
+description = "RNA complement of thymine is adenine"
+
+[aade8964-02e1-4073-872f-42d3ffd74c5f]
+description = "RNA complement of adenine is uracil"
+
+[79ed2757-f018-4f47-a1d7-34a559392dbf]
+description = "RNA complement"

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -1,0 +1,67 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[19828a3a-fbf7-4661-8ddd-cbaeee0e2178]
+description = "1 is I"
+
+[f088f064-2d35-4476-9a41-f576da3f7b03]
+description = "2 is II"
+
+[b374a79c-3bea-43e6-8db8-1286f79c7106]
+description = "3 is III"
+
+[05a0a1d4-a140-4db1-82e8-fcc21fdb49bb]
+description = "4 is IV"
+
+[57c0f9ad-5024-46ab-975d-de18c430b290]
+description = "5 is V"
+
+[20a2b47f-e57f-4797-a541-0b3825d7f249]
+description = "6 is VI"
+
+[ff3fb08c-4917-4aab-9f4e-d663491d083d]
+description = "9 is IX"
+
+[2bda64ca-7d28-4c56-b08d-16ce65716cf6]
+description = "27 is XXVII"
+
+[a1f812ef-84da-4e02-b4f0-89c907d0962c]
+description = "48 is XLVIII"
+
+[607ead62-23d6-4c11-a396-ef821e2e5f75]
+description = "49 is XLIX"
+
+[d5b283d4-455d-4e68-aacf-add6c4b51915]
+description = "59 is LIX"
+
+[46b46e5b-24da-4180-bfe2-2ef30b39d0d0]
+description = "93 is XCIII"
+
+[30494be1-9afb-4f84-9d71-db9df18b55e3]
+description = "141 is CXLI"
+
+[267f0207-3c55-459a-b81d-67cec7a46ed9]
+description = "163 is CLXIII"
+
+[cdb06885-4485-4d71-8bfb-c9d0f496b404]
+description = "402 is CDII"
+
+[6b71841d-13b2-46b4-ba97-dec28133ea80]
+description = "575 is DLXXV"
+
+[432de891-7fd6-4748-a7f6-156082eeca2f]
+description = "911 is CMXI"
+
+[e6de6d24-f668-41c0-88d7-889c0254d173]
+description = "1024 is MXXIV"
+
+[bb550038-d4eb-4be2-a9ce-f21961ac3bc6]
+description = "3000 is MMM"

--- a/exercises/practice/run-length-encoding/.meta/tests.toml
+++ b/exercises/practice/run-length-encoding/.meta/tests.toml
@@ -1,0 +1,49 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[ad53b61b-6ffc-422f-81a6-61f7df92a231]
+description = "run-length encode a string -> empty string"
+
+[52012823-b7e6-4277-893c-5b96d42f82de]
+description = "run-length encode a string -> single characters only are encoded without count"
+
+[b7868492-7e3a-415f-8da3-d88f51f80409]
+description = "run-length encode a string -> string with no single characters"
+
+[859b822b-6e9f-44d6-9c46-6091ee6ae358]
+description = "run-length encode a string -> single characters mixed with repeated characters"
+
+[1b34de62-e152-47be-bc88-469746df63b3]
+description = "run-length encode a string -> multiple whitespace mixed in string"
+
+[abf176e2-3fbd-40ad-bb2f-2dd6d4df721a]
+description = "run-length encode a string -> lowercase characters"
+
+[7ec5c390-f03c-4acf-ac29-5f65861cdeb5]
+description = "run-length decode a string -> empty string"
+
+[ad23f455-1ac2-4b0e-87d0-b85b10696098]
+description = "run-length decode a string -> single characters only"
+
+[21e37583-5a20-4a0e-826c-3dee2c375f54]
+description = "run-length decode a string -> string with no single characters"
+
+[1389ad09-c3a8-4813-9324-99363fba429c]
+description = "run-length decode a string -> single characters with repeated characters"
+
+[3f8e3c51-6aca-4670-b86c-a213bf4706b0]
+description = "run-length decode a string -> multiple whitespace mixed in string"
+
+[29f721de-9aad-435f-ba37-7662df4fb551]
+description = "run-length decode a string -> lowercase string"
+
+[2a762efd-8695-4e04-b0d6-9736899fbc16]
+description = "encode and then decode -> encode followed by decode gives original string"

--- a/exercises/practice/trinary/.meta/tests.toml
+++ b/exercises/practice/trinary/.meta/tests.toml
@@ -1,0 +1,43 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[a7a79a9e-5606-454c-9cdb-4f3c0ca46931]
+description = "trinary 1 is decimal 1"
+
+[39240078-13e2-4eb8-87c4-aeffa7d64130]
+description = "trinary 2 is decimal 2"
+
+[81900d67-7e07-4d41-a71e-86f1cd72ce1f]
+description = "trinary 10 is decimal 3"
+
+[7a8d5341-f88a-4c60-9048-4d5e017fa701]
+description = "trinary 11 is decimal 4"
+
+[6b3c37f6-d6b3-4575-85c0-19f48dd101af]
+description = "trinary 100 is decimal 9"
+
+[a210b2b8-d333-4e19-9e59-87cabdd2a0ba]
+description = "trinary 112 is decimal 14"
+
+[5ae03472-b942-42ce-ba00-e84a7dc86dd8]
+description = "trinary 222 is decimal 26"
+
+[d4fabf94-6149-4d1e-b42f-b34dc3ddef8f]
+description = "trinary 1122000120 is decimal 32091"
+
+[34be152d-38f3-4dcf-b5ab-9e14fe2f7161]
+description = "invalid trinary digits returns 0"
+
+[b57aa24d-3da2-4787-9429-5bc94d3112d6]
+description = "invalid word as input returns 0"
+
+[673c2057-5d89-483c-87fa-139da6927b90]
+description = "invalid numbers with letters as input returns 0"

--- a/exercises/practice/two-fer/.meta/tests.toml
+++ b/exercises/practice/two-fer/.meta/tests.toml
@@ -1,0 +1,19 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce]
+description = "no name given"
+
+[b4c6dbb8-b4fb-42c2-bafd-10785abe7709]
+description = "a name given"
+
+[3549048d-1a6e-4653-9a79-b0bda163e8d5]
+description = "another name given"

--- a/exercises/practice/word-count/.meta/tests.toml
+++ b/exercises/practice/word-count/.meta/tests.toml
@@ -1,0 +1,49 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[61559d5f-2cad-48fb-af53-d3973a9ee9ef]
+description = "count one word"
+
+[5abd53a3-1aed-43a4-a15a-29f88c09cbbd]
+description = "count one of each word"
+
+[2a3091e5-952e-4099-9fac-8f85d9655c0e]
+description = "multiple occurrences of a word"
+
+[e81877ae-d4da-4af4-931c-d923cd621ca6]
+description = "handles cramped lists"
+
+[7349f682-9707-47c0-a9af-be56e1e7ff30]
+description = "handles expanded lists"
+
+[a514a0f2-8589-4279-8892-887f76a14c82]
+description = "ignore punctuation"
+
+[d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e]
+description = "include numbers"
+
+[dac6bc6a-21ae-4954-945d-d7f716392dbf]
+description = "normalize case"
+
+[4185a902-bdb0-4074-864c-f416e42a0f19]
+description = "with apostrophes"
+
+[be72af2b-8afe-4337-b151-b297202e4a7b]
+description = "with quotations"
+
+[8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6]
+description = "substrings from the beginning"
+
+[c5f4ef26-f3f7-4725-b314-855c04fb4c13]
+description = "multiple spaces not detected as a word"
+
+[50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360]
+description = "alternating word separators not detected as a word"


### PR DESCRIPTION
We're in the process of re-opening the [Problem Specifications repo](https://github.com/exercism/problem-specifications), as discussed in [this issue](https://github.com/exercism/problem-specifications/issues/1674).
This PR adds `.meta/tests.toml` files for all exercises for which canonical data is defined in the Problem Specifications repo.
We'll now discuss _why_ we're making this change.
## Keeping track of implemented tests
While most of the changes to the Problem Specifications repo are specific to that repo, there is one track-specific change:
> If a track implements an exercise for which test data exists, the exercise _must_ contain a `.meta/tests.toml` file.
The goal of the `tests.toml` file is to keep track of which tests are implemented by the exercise.
Tests in this file are identified by their UUID and each test has a boolean value that indicates if it is implemented by that exercise.
A `tests.toml` file for a track's `two-fer` exercise looks like this:
```toml
[canonical-tests]
# no name given
"19709124-b82e-4e86-a722-9e5c5ebf3952" = true
# a name given
"3451eebd-123f-4256-b667-7b109affce32" = true
# another name given
"653611c6-be9f-4935-ab42-978e25fe9a10" = false
```
In this case, the track has chosen to implement two of the three available tests.
If a track uses a _test generator_ to generate an exercise's test suite, it _must_ use the contents of the `tests.toml` file to determine which tests to include in the generated test suite.
## Tooling
To make it easy to keep the `tests.toml` up to date, tracks can use the [`canonical_data_syncer` application](https://github.com/exercism/canonical-data-syncer).
This application is a small, standalone binary that will compare the tests specified in the `tests.toml` files against the tests that are defined in the exercise's canonical data.
It then interactively gives the maintainer the option to include or exclude test cases that are currently missing, updating the `tests.toml` file accordingly.
To use the canonical data syncer tool, tracks should copying the [`fetch-canonical_data_syncer`](https://github.com/exercism/canonical-data-syncer/blob/master/scripts/fetch-canonical_data_syncer) and/or [`fetch-canonical_data_syncer.ps1`](https://github.com/exercism/canonical-data-syncer/blob/master/scripts/fetch-canonical_data_syncer.ps1) scripts into their repository.
Then, running either of these scripts will download the latest version of the tool to the track's `bin` directory.
The tool can be run using `./bin/canonical_data_syncer` or `.\bin\canonical_data_syncer.exe`, depending on your operating system.
## Changes
In this PR, we're adding `meta/tests.toml` files for all the exercises for which canonical data is defined.
We've initially marked all tests as _included_, which means that we'll assume that your track has implemented those tests.
If there isn't anything obviously wrong with the PR, I would suggest to merge this PR first, and then later on update the `meta/tests.toml` files according to your track's actual implementation.
