### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,2 +1,4 @@
+# Setup
+
 Check out [Exercism Help](http://exercism.io/languages/elisp) for instructions getting started with Emacs and
 Emacs Lisp.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -6,17 +6,17 @@ install [GNU Emacs](http://www.gnu.org/software/emacs/) first.
 It is recommended to get the latest Emacs, currently 24.5-1, but 24.4 or higher
 should be considered the target implementation for the exercises.
 
-### On OS X
+## On OS X
 The easiest way is to visit [Emacs For Mac OS X](http://emacsformacosx.com/) and download the dmg, which will
 install GNU Emacs as a packaged OS X app.
 
 Alternatives exist, such as Aquamacs (not recommended) or installing via
 Homebrew, if you prefer.
 
-### On Linux
+## On Linux
 On some distros, Emacs is already installed, since it's part of GNU.
 
-#### Ubuntu
+### Ubuntu
 Prior to Ubuntu 15.04 "vivid vervet", the highest available Emacs version was
 24.3, so you'll need to use a [PPA](https://launchpad.net/ubuntu/+ppas?name_filter=emacs) or [build from source](http://linuxg.net/how-to-install-emacs-24-4-on-ubuntu-14-10-ubuntu-14-04-and-derivative-systems/) if you're on 14.10 or
 earlier.
@@ -27,7 +27,7 @@ Otherwise, if you're running vivid, it should be as simple as
 sudo apt-get install emacs
 ```
 
-#### Arch
+### Arch
 Arch currently ships with the latest Emacs 24.5-1, so run:
 
 ```
@@ -36,7 +36,7 @@ sudo pacman -S emacs
 
 and you should be set.
 
-#### Other distros
+### Other distros
 Check with your distro to see what version is current, and use your package
 manager or build from source as appropriate.
 

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 So you've installed Emacs. Now what?
 
 Well, you can start the tutoral by pressing `C-h t`, and that's not a bad place

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -24,14 +24,14 @@ submission. The above command is a bit unwieldy, so if you like:
 You should be able to simply call `ert-run exercise-test.el` and run the tests
 in batch mode.
 
-### Working on exercises
+## Working on exercises
 Since Emacs is, itself, an elisp interpreter, your working code is always in its
 native execution environment. You can evaluate any form by pressing `C-x e` at
 the end of the form, or a selection with `M-x eval-region` or the whole buffer
 with `M-x eval-buffer`. This can be extremely useful for quickly debugging your
 code.
 
-### Suggestions
+## Suggestions
 Since both your code and tests are valid elisp, it is suggested to work with
 your exercise code in a buffer pane side-by side with its test, like so:
 


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
