### PR TITLE
Include an even year in tests

### DIFF
--- a/exercises/practice/leap/leap-test.el
+++ b/exercises/practice/leap/leap-test.el
@@ -12,7 +12,7 @@
   (should-not (leap-year-p 1997)))
 
 (ert-deftest non-leap-even-year ()
-  (should-not (leap-year-p 1997)))
+  (should-not (leap-year-p 1998)))
 
 (ert-deftest century ()
   (should-not (leap-year-p 1900)))


### PR DESCRIPTION
This test was identical to the one above. Based on the test name, I
think that the year tested should be even.