### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "63fdb535-1b25-41bd-91e0-0c79ac5e3949",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Emacs Lisp locally",
+      "blurb": "Learn how to install Emacs Lisp locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "72043d0f-bc50-44b9-9701-9b3fbd400749",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Emacs Lisp",
+      "blurb": "An overview of how to get started from scratch with Emacs Lisp"
+    },
+    {
+      "uuid": "8e1eabd3-16da-4329-8d5e-1db4abd4e334",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Emacs Lisp track",
+      "blurb": "Learn how to test your Emacs Lisp exercises on Exercism"
+    },
+    {
+      "uuid": "c7cc3ef7-c39a-4d7d-b65a-c904e60334ee",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Emacs Lisp resources",
+      "blurb": "A collection of useful resources to help you master Emacs Lisp"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
