### PR TITLE
🤖 Add labels append file

### DIFF
--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -1,0 +1,44 @@
+- name: "bug"
+  description: ""
+  color: "fc2929"
+
+- name: "duplicate"
+  description: ""
+  color: "cccccc"
+
+- name: "enhancement"
+  description: ""
+  color: "84b6eb"
+
+- name: "first-timers only"
+  description: ""
+  color: "159818"
+
+- name: "good first patch"
+  description: ""
+  color: "159818"
+
+- name: "help wanted"
+  description: ""
+  color: "159818"
+
+- name: "invalid"
+  description: ""
+  color: "e6e6e6"
+
+- name: "pinned"
+  description: ""
+  color: "AAAAAA"
+
+- name: "question"
+  description: ""
+  color: "cc317c"
+
+- name: "v3-migration 🤖"
+  description: "Preparing for Exercism v3"
+  color: "E99695"
+
+- name: "wontfix"
+  description: ""
+  color: "ffffff"
+


### PR DESCRIPTION
This PR adds a `.appends/.github/labels.yml` file, which contains all the labels that are currently used in this repo. The `.github/labels.yml` file will contain the full list of labels that this repo can use, which will be a combination of the `.appends/.github/labels.yml` file and a centrally-managed `labels.yml` file.

We'll automatically sync any changes, which allows us to guarantee that all the track repositories will have a pre-determined set of labels, augmented with any custom labels defined in the `.appends/.github/labels.yml` file. This syncing will be done by another (automatically-synced) workflow, which we will add in a later PR.

## Tracking

https://github.com/exercism/v3-launch/issues/41