### PR TITLE
Perfect Numbers: Fix "zero" test case

### DIFF
--- a/exercises/practice/perfect-numbers/perfect-numbers-test.el
+++ b/exercises/practice/perfect-numbers/perfect-numbers-test.el
@@ -46,7 +46,7 @@
 (ert-deftest zero-is-rejected ()
   (should
    (equal
-    (should-error (classify -1))
+    (should-error (classify 0))
     '(error . ("Classification is only possible for natural numbers")))))
 
 (ert-deftest negative-integer-is-rejected ()


### PR DESCRIPTION
This test states that it tests the case where the number is `0`, yet `-1` is passed to the `classify` function.