### PR TITLE
Binary exercise: Test invalid binary string beginning with binary

### DIFF
--- a/exercises/practice/binary/binary-test.el
+++ b/exercises/practice/binary/binary-test.el
@@ -30,5 +30,8 @@
 (ert-deftest invalid-binary-is-decimal-0 ()
   (should (= 0 (to-decimal "carrot"))))
 
+(ert-deftest invalid-binary-incl-binary-format-is-decimal-0 ()
+  (should (= 0 (to-decimal "10151"))))
+
 (provide 'binary-test)
 ;;; binary-test.el ends here


### PR DESCRIPTION
At least one of the currently starred published solutions fails this test.