### PR TITLE
Fix: GHA ci.yml doesn't fail if exercise tests are failing

### DIFF
--- a/bin/test-examples
+++ b/bin/test-examples
@@ -14,8 +14,8 @@ for exercise in *; do
     mv "${exercise}.el" "${exercise}.el.bak"
     mv .meta/example.el "${exercise}.el"
     emacs -batch -l ert -l "${exercise}-test.el" -f ert-run-tests-batch-and-exit
-    mv "${exercise}.el.bak" "${exercise}.el"
     let "err_cnt += $?"
+    mv "${exercise}.el.bak" "${exercise}.el"
     popd
 done
 popd > /dev/null


### PR DESCRIPTION
-
https://github.com/exercism/emacs-lisp/blob/8848da5d17e639f61bb9840fd55d12ee5b1873f3/.github/workflows/ci.yml
  didn't exit with an error code if exercise tests where failing
- This was noticed because the tests for https://github.com/exercism/emacs-lisp/pull/210 did fail but the bash script didn't register the failure.