### PR TITLE
Upgrade Emacs version to 28.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Install project dependencies
         env:
-          EMACS_VERSION: 26.1
+          EMACS_VERSION: 28.1
         run: |
           export EMACS_DIR=$HOME/emacs
           # Install Emacs 26 from upstream


### PR DESCRIPTION
CI runner in this repository should match runner in production.
See https://github.com/exercism/emacs-lisp-test-runner/commit/74b026194a2a9ca34c84dc3a1030293971e71442