### PR TITLE
Enable lexical binding for all Emacs Lisp source files

### DIFF
--- a/exercises/practice/acronym/.meta/example.el
+++ b/exercises/practice/acronym/.meta/example.el
@@ -1,4 +1,4 @@
-;;; acronym.el --- Acronym (exercism)
+;;; acronym.el --- Acronym (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/acronym/acronym-test.el
+++ b/exercises/practice/acronym/acronym-test.el
@@ -1,4 +1,4 @@
-;;; acronym-test.el --- Tests for Acronym (exercism)
+;;; acronym-test.el --- Tests for Acronym (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/acronym/acronym.el
+++ b/exercises/practice/acronym/acronym.el
@@ -1,4 +1,4 @@
-;;; acronym.el --- Acronym (exercism)
+;;; acronym.el --- Acronym (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/allergies/.meta/example.el
+++ b/exercises/practice/allergies/.meta/example.el
@@ -1,4 +1,4 @@
-;;; allergies.el --- Allergies Exercise (exercism)
+;;; allergies.el --- Allergies Exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/allergies/allergies-test.el
+++ b/exercises/practice/allergies/allergies-test.el
@@ -1,4 +1,4 @@
-;;; allergies-test.el --- Tests for Allergies (exercism)
+;;; allergies-test.el --- Tests for Allergies (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/allergies/allergies.el
+++ b/exercises/practice/allergies/allergies.el
@@ -1,4 +1,4 @@
-;;; allergies.el --- Allergies Exercise (exercism)
+;;; allergies.el --- Allergies Exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/anagram/.meta/example.el
+++ b/exercises/practice/anagram/.meta/example.el
@@ -1,4 +1,4 @@
-;;; anagram.el --- Anagram (exercism)
+;;; anagram.el --- Anagram (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/anagram/anagram-test.el
+++ b/exercises/practice/anagram/anagram-test.el
@@ -1,4 +1,4 @@
-;;; anagram-test.el --- Tests for Anagram (exercism)
+;;; anagram-test.el --- Tests for Anagram (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/anagram/anagram.el
+++ b/exercises/practice/anagram/anagram.el
@@ -1,4 +1,4 @@
-;;; anagram.el --- Anagram (exercism)
+;;; anagram.el --- Anagram (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/armstrong-numbers/.meta/example.el
+++ b/exercises/practice/armstrong-numbers/.meta/example.el
@@ -1,4 +1,4 @@
-;;; armstrong-numbers.el --- armstrong-numbers Exercise (exercism)
+;;; armstrong-numbers.el --- armstrong-numbers Exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/armstrong-numbers/armstrong-numbers-test.el
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers-test.el
@@ -1,4 +1,4 @@
-;;; armstrong-numbers-test.el --- Tests for armstrong-numbers (exercism)
+;;; armstrong-numbers-test.el --- Tests for armstrong-numbers (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/armstrong-numbers/armstrong-numbers.el
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers.el
@@ -1,4 +1,4 @@
-;;; armstrong-numbers.el --- armstrong-numbers Exercise (exercism)
+;;; armstrong-numbers.el --- armstrong-numbers Exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/atbash-cipher/.meta/example.el
+++ b/exercises/practice/atbash-cipher/.meta/example.el
@@ -1,4 +1,4 @@
-;;; atbash-cipher.el --- Atbash-Cipher (exercism)
+;;; atbash-cipher.el --- Atbash-Cipher (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 ;;;

--- a/exercises/practice/atbash-cipher/atbash-cipher-test.el
+++ b/exercises/practice/atbash-cipher/atbash-cipher-test.el
@@ -1,4 +1,4 @@
-;;; atbash-cipher-test.el --- Tests for Atbash Cipher (exercism)
+;;; atbash-cipher-test.el --- Tests for Atbash Cipher (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/atbash-cipher/atbash-cipher.el
+++ b/exercises/practice/atbash-cipher/atbash-cipher.el
@@ -1,4 +1,4 @@
-;;; atbash-cipher.el --- Atbash-Cipher (exercism)
+;;; atbash-cipher.el --- Atbash-Cipher (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/binary/.meta/example.el
+++ b/exercises/practice/binary/.meta/example.el
@@ -1,4 +1,4 @@
-;;; binary.el --- Binary exercise (exercism)
+;;; binary.el --- Binary exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/binary/binary-test.el
+++ b/exercises/practice/binary/binary-test.el
@@ -1,4 +1,4 @@
-;;; binary-test.el --- Tests for Binary exercise (exercism)
+;;; binary-test.el --- Tests for Binary exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/binary/binary.el
+++ b/exercises/practice/binary/binary.el
@@ -1,4 +1,4 @@
-;;; binary.el --- Binary exercise (exercism)
+;;; binary.el --- Binary exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/bob/.meta/example.el
+++ b/exercises/practice/bob/.meta/example.el
@@ -1,4 +1,4 @@
-;;; bob.el --- Bob exercise (exercism)
+;;; bob.el --- Bob exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/bob/bob-test.el
+++ b/exercises/practice/bob/bob-test.el
@@ -1,4 +1,4 @@
-;;; bob-test.el --- ERT tests for Bob (exercism)
+;;; bob-test.el --- ERT tests for Bob (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 ;; Common test data version: 1.2.0 6dc2014

--- a/exercises/practice/bob/bob.el
+++ b/exercises/practice/bob/bob.el
@@ -1,4 +1,4 @@
-;;; bob.el --- Bob exercise (exercism)
+;;; bob.el --- Bob exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/crypto-square/.meta/example.el
+++ b/exercises/practice/crypto-square/.meta/example.el
@@ -1,4 +1,4 @@
-;;; crypto-square.el --- Crypto Square (exercism)
+;;; crypto-square.el --- Crypto Square (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/crypto-square/crypto-square-test.el
+++ b/exercises/practice/crypto-square/crypto-square-test.el
@@ -1,4 +1,4 @@
-;;; crypto-square-test.el --- Tests for Crypto Square (exercism)
+;;; crypto-square-test.el --- Tests for Crypto Square (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/crypto-square/crypto-square.el
+++ b/exercises/practice/crypto-square/crypto-square.el
@@ -1,4 +1,4 @@
-;;; crypto-square.el --- Crypto Square (exercism)
+;;; crypto-square.el --- Crypto Square (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/difference-of-squares/.meta/example.el
+++ b/exercises/practice/difference-of-squares/.meta/example.el
@@ -1,4 +1,4 @@
-;;; difference-of-squares.el --- Difference of Squares (exercism)
+;;; difference-of-squares.el --- Difference of Squares (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/difference-of-squares/difference-of-squares-test.el
+++ b/exercises/practice/difference-of-squares/difference-of-squares-test.el
@@ -1,4 +1,4 @@
-;;; difference-of-squares-test.el --- Tests for difference-of-squares (exercism)
+;;; difference-of-squares-test.el --- Tests for difference-of-squares (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/difference-of-squares/difference-of-squares.el
+++ b/exercises/practice/difference-of-squares/difference-of-squares.el
@@ -1,4 +1,4 @@
-;;; difference-of-squares.el --- Difference of Squares (exercism)
+;;; difference-of-squares.el --- Difference of Squares (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/etl/.meta/example.el
+++ b/exercises/practice/etl/.meta/example.el
@@ -1,4 +1,4 @@
-;;; etl.el --- etl Exercise (exercism)
+;;; etl.el --- etl Exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/etl/etl-test.el
+++ b/exercises/practice/etl/etl-test.el
@@ -1,4 +1,4 @@
-;;; etl-test.el --- Tests for etl (exercism)
+;;; etl-test.el --- Tests for etl (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/etl/etl.el
+++ b/exercises/practice/etl/etl.el
@@ -1,4 +1,4 @@
-;;; etl.el --- etl Exercise (exercism)
+;;; etl.el --- etl Exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/gigasecond/.meta/example.el
+++ b/exercises/practice/gigasecond/.meta/example.el
@@ -1,4 +1,4 @@
-;;; gigasecond.el --- Gigasecond exercise (exercism)
+;;; gigasecond.el --- Gigasecond exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 ;; Calculate the date one gigasecond (10^9 seconds) from the

--- a/exercises/practice/gigasecond/gigasecond-test.el
+++ b/exercises/practice/gigasecond/gigasecond-test.el
@@ -1,4 +1,4 @@
-;;; gigasecond-test.el --- ERT tests for gigasecond (exercism)
+;;; gigasecond-test.el --- ERT tests for gigasecond (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 ;;

--- a/exercises/practice/gigasecond/gigasecond.el
+++ b/exercises/practice/gigasecond/gigasecond.el
@@ -1,4 +1,4 @@
-;;; gigasecond.el --- Gigasecond exercise (exercism)
+;;; gigasecond.el --- Gigasecond exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 ;; Calculate the date one gigasecond (10^9 seconds) from the

--- a/exercises/practice/grains/.meta/example.el
+++ b/exercises/practice/grains/.meta/example.el
@@ -1,4 +1,4 @@
-;;; grains.el --- Grains exercise (exercism)
+;;; grains.el --- Grains exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/grains/grains-test.el
+++ b/exercises/practice/grains/grains-test.el
@@ -1,4 +1,4 @@
-;;; grains-test.el --- Test for Grains (exercism)
+;;; grains-test.el --- Test for Grains (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/grains/grains.el
+++ b/exercises/practice/grains/grains.el
@@ -1,4 +1,4 @@
-;;; grains.el --- Grains exercise (exercism)
+;;; grains.el --- Grains exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/hamming/.meta/example.el
+++ b/exercises/practice/hamming/.meta/example.el
@@ -1,4 +1,4 @@
-;;; hamming.el --- Hamming (exercism)
+;;; hamming.el --- Hamming (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/hamming/hamming-test.el
+++ b/exercises/practice/hamming/hamming-test.el
@@ -1,4 +1,4 @@
-;;; hamming-test.el --- Tests for hamming (exercism)
+;;; hamming-test.el --- Tests for hamming (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 ;; Common test data version: 2.0.1 f79dfd7

--- a/exercises/practice/hamming/hamming.el
+++ b/exercises/practice/hamming/hamming.el
@@ -1,4 +1,4 @@
-;;; hamming.el --- Hamming (exercism)
+;;; hamming.el --- Hamming (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/hello-world/.meta/example.el
+++ b/exercises/practice/hello-world/.meta/example.el
@@ -1,4 +1,4 @@
-;;; hello-world.el --- Hello World Exercise (exercism)
+;;; hello-world.el --- Hello World Exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/hello-world/hello-world-test.el
+++ b/exercises/practice/hello-world/hello-world-test.el
@@ -1,4 +1,4 @@
-;;; hello-world-test.el --- Tests for Hello World (exercism)
+;;; hello-world-test.el --- Tests for Hello World (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 ;; Common test data version: 1.1.0 be3ae66

--- a/exercises/practice/hello-world/hello-world.el
+++ b/exercises/practice/hello-world/hello-world.el
@@ -1,4 +1,4 @@
-(defun hello ()
+(defun hello ()  -*- lexical-binding: t; -*-
   "Goodbye, Mars!")
 
 (provide 'hello-world)

--- a/exercises/practice/leap/.meta/example.el
+++ b/exercises/practice/leap/.meta/example.el
@@ -1,4 +1,4 @@
-;;; leap.el --- Leap exercise (exercism)
+;;; leap.el --- Leap exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/leap/leap-test.el
+++ b/exercises/practice/leap/leap-test.el
@@ -1,4 +1,4 @@
-;;; leap-test.el --- Tests for Leap exercise (exercism)
+;;; leap-test.el --- Tests for Leap exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/leap/leap.el
+++ b/exercises/practice/leap/leap.el
@@ -1,4 +1,4 @@
-;;; leap.el --- Leap exercise (exercism)
+;;; leap.el --- Leap exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/luhn/.meta/example.el
+++ b/exercises/practice/luhn/.meta/example.el
@@ -1,4 +1,4 @@
-;;; luhn.el --- luhn (exercism)
+;;; luhn.el --- luhn (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/luhn/luhn-test.el
+++ b/exercises/practice/luhn/luhn-test.el
@@ -1,4 +1,4 @@
-;;; luhn-test.el --- Tests for luhn (exercism)
+;;; luhn-test.el --- Tests for luhn (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/luhn/luhn.el
+++ b/exercises/practice/luhn/luhn.el
@@ -1,4 +1,4 @@
-;;; luhn.el --- Luhn exercise (exercism)
+;;; luhn.el --- Luhn exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/nucleotide-count/.meta/example.el
+++ b/exercises/practice/nucleotide-count/.meta/example.el
@@ -1,4 +1,4 @@
-;;; nucleotide-count.el --- nucleotide-count Exercise (exercism)
+;;; nucleotide-count.el --- nucleotide-count Exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/nucleotide-count/nucleotide-count-test.el
+++ b/exercises/practice/nucleotide-count/nucleotide-count-test.el
@@ -1,4 +1,4 @@
-;;; nucleotide-count-test.el --- Tests for nucleotide-count (exercism)
+;;; nucleotide-count-test.el --- Tests for nucleotide-count (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/nucleotide-count/nucleotide-count.el
+++ b/exercises/practice/nucleotide-count/nucleotide-count.el
@@ -1,4 +1,4 @@
-;;; nucleotide-count.el --- nucleotide-count Exercise (exercism)
+;;; nucleotide-count.el --- nucleotide-count Exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/pangram/.meta/example.el
+++ b/exercises/practice/pangram/.meta/example.el
@@ -1,4 +1,4 @@
-;;; pangram.el --- Pangram (exercism)
+;;; pangram.el --- Pangram (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/pangram/pangram-test.el
+++ b/exercises/practice/pangram/pangram-test.el
@@ -1,4 +1,4 @@
-;;; pagram-test.el --- Tests for Pangram (exercism)
+;;; pagram-test.el --- Tests for Pangram (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 ;; Common test data version: 1.3.0 d79e13e

--- a/exercises/practice/pangram/pangram.el
+++ b/exercises/practice/pangram/pangram.el
@@ -1,4 +1,4 @@
-;;; pangram.el --- Pangram (exercism)
+;;; pangram.el --- Pangram (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/perfect-numbers/.meta/example.el
+++ b/exercises/practice/perfect-numbers/.meta/example.el
@@ -1,4 +1,4 @@
-;;; perfect-numbers.el --- perfect-numbers Exercise (exercism)
+;;; perfect-numbers.el --- perfect-numbers Exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/perfect-numbers/perfect-numbers-test.el
+++ b/exercises/practice/perfect-numbers/perfect-numbers-test.el
@@ -1,4 +1,4 @@
-;;; perfect-numbers-test.el --- Tests for perfect-numbers (exercism)
+;;; perfect-numbers-test.el --- Tests for perfect-numbers (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/perfect-numbers/perfect-numbers.el
+++ b/exercises/practice/perfect-numbers/perfect-numbers.el
@@ -1,4 +1,4 @@
-;;; perfect-numbers.el --- perfect-numbers Exercise (exercism)
+;;; perfect-numbers.el --- perfect-numbers Exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/phone-number/.meta/example.el
+++ b/exercises/practice/phone-number/.meta/example.el
@@ -1,4 +1,4 @@
-;;; phone-number.el --- phone-number Exercise (exercism)
+;;; phone-number.el --- phone-number Exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/phone-number/phone-number-test.el
+++ b/exercises/practice/phone-number/phone-number-test.el
@@ -1,4 +1,4 @@
-;;; phone-number-test.el --- Tests for phone-number (exercism)
+;;; phone-number-test.el --- Tests for phone-number (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/phone-number/phone-number.el
+++ b/exercises/practice/phone-number/phone-number.el
@@ -1,4 +1,4 @@
-;;; phone-number.el --- phone-number Exercise (exercism)
+;;; phone-number.el --- phone-number Exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/raindrops/.meta/example.el
+++ b/exercises/practice/raindrops/.meta/example.el
@@ -1,4 +1,4 @@
-;;; raindrops.el --- Raindrops (exercism)
+;;; raindrops.el --- Raindrops (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/raindrops/raindrops-test.el
+++ b/exercises/practice/raindrops/raindrops-test.el
@@ -1,4 +1,4 @@
-;;; raindrops-test.el --- Tests for Raindrops (exercism)
+;;; raindrops-test.el --- Tests for Raindrops (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/raindrops/raindrops.el
+++ b/exercises/practice/raindrops/raindrops.el
@@ -1,4 +1,4 @@
-;;; raindrops.el --- Raindrops (exercism)
+;;; raindrops.el --- Raindrops (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/rna-transcription/.meta/example.el
+++ b/exercises/practice/rna-transcription/.meta/example.el
@@ -1,4 +1,4 @@
-;;; rna-transcription.el -- RNA Transcription (exercism)
+;;; rna-transcription.el -- RNA Transcription (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 ;;

--- a/exercises/practice/rna-transcription/rna-transcription-test.el
+++ b/exercises/practice/rna-transcription/rna-transcription-test.el
@@ -1,4 +1,4 @@
-;;; rna-transcription-test.el --- Tests for RNA Transcription (exercism)
+;;; rna-transcription-test.el --- Tests for RNA Transcription (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/rna-transcription/rna-transcription.el
+++ b/exercises/practice/rna-transcription/rna-transcription.el
@@ -1,4 +1,4 @@
-;;; rna-transcription.el -- RNA Transcription (exercism)
+;;; rna-transcription.el -- RNA Transcription (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/robot-name/.meta/example.el
+++ b/exercises/practice/robot-name/.meta/example.el
@@ -1,4 +1,4 @@
-;;; robot-name.el --- Robot Name (exercism)
+;;; robot-name.el --- Robot Name (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 ;;

--- a/exercises/practice/robot-name/robot-name-test.el
+++ b/exercises/practice/robot-name/robot-name-test.el
@@ -1,4 +1,4 @@
-;;; robot-name-test.el --- Tests for Robot Name (exercism)
+;;; robot-name-test.el --- Tests for Robot Name (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/robot-name/robot-name.el
+++ b/exercises/practice/robot-name/robot-name.el
@@ -1,4 +1,4 @@
-;;; robot-name.el --- Robot Name (exercism)
+;;; robot-name.el --- Robot Name (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 ;;

--- a/exercises/practice/roman-numerals/.meta/example.el
+++ b/exercises/practice/roman-numerals/.meta/example.el
@@ -1,4 +1,4 @@
-;;; roman-numerals.el --- roman-numerals Exercise (exercism)
+;;; roman-numerals.el --- roman-numerals Exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/roman-numerals/roman-numerals-test.el
+++ b/exercises/practice/roman-numerals/roman-numerals-test.el
@@ -1,4 +1,4 @@
-;;; roman-numerals-test.el --- Tests for roman-numerals (exercism)
+;;; roman-numerals-test.el --- Tests for roman-numerals (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/roman-numerals/roman-numerals.el
+++ b/exercises/practice/roman-numerals/roman-numerals.el
@@ -1,4 +1,4 @@
-;;; roman-numerals.el --- roman-numerals Exercise (exercism)
+;;; roman-numerals.el --- roman-numerals Exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/run-length-encoding/.meta/example.el
+++ b/exercises/practice/run-length-encoding/.meta/example.el
@@ -1,4 +1,4 @@
-;;; run-length-encoding.el --- run-length-encoding Exercise (exercism)
+;;; run-length-encoding.el --- run-length-encoding Exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/run-length-encoding/run-length-encoding-test.el
+++ b/exercises/practice/run-length-encoding/run-length-encoding-test.el
@@ -1,4 +1,4 @@
-;;; run-length-encoding-test.el --- Tests for run-length-encoding (exercism)
+;;; run-length-encoding-test.el --- Tests for run-length-encoding (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/run-length-encoding/run-length-encoding.el
+++ b/exercises/practice/run-length-encoding/run-length-encoding.el
@@ -1,4 +1,4 @@
-;;; run-length-encoding.el --- run-length-encoding Exercise (exercism)
+;;; run-length-encoding.el --- run-length-encoding Exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/trinary/.meta/example.el
+++ b/exercises/practice/trinary/.meta/example.el
@@ -1,4 +1,4 @@
-;;; trinary.el --- Trinary (exercism)
+;;; trinary.el --- Trinary (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/trinary/trinary-test.el
+++ b/exercises/practice/trinary/trinary-test.el
@@ -1,4 +1,4 @@
-;;; trinary-test.el --- Tests for Trinary (exercism)
+;;; trinary-test.el --- Tests for Trinary (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/trinary/trinary.el
+++ b/exercises/practice/trinary/trinary.el
@@ -1,4 +1,4 @@
-;;; trinary.el --- Trinary (exercism)
+;;; trinary.el --- Trinary (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/two-fer/.meta/example.el
+++ b/exercises/practice/two-fer/.meta/example.el
@@ -1,4 +1,4 @@
-;;; two-fer.el --- Two-fer Exercise (exercism)
+;;; two-fer.el --- Two-fer Exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/two-fer/two-fer-test.el
+++ b/exercises/practice/two-fer/two-fer-test.el
@@ -1,4 +1,4 @@
-;;; two-fer-test.el --- Tests for Two-fer (exercism)
+;;; two-fer-test.el --- Tests for Two-fer (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 ;; Common test data version: 1.2.0 4fc1acb

--- a/exercises/practice/two-fer/two-fer.el
+++ b/exercises/practice/two-fer/two-fer.el
@@ -1,4 +1,4 @@
-;;; two-fer.el --- Two-fer Exercise (exercism)
+;;; two-fer.el --- Two-fer Exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/word-count/.meta/example.el
+++ b/exercises/practice/word-count/.meta/example.el
@@ -1,4 +1,4 @@
-;;; word-count.el --- word-count Exercise (exercism)
+;;; word-count.el --- word-count Exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/word-count/word-count-test.el
+++ b/exercises/practice/word-count/word-count-test.el
@@ -1,4 +1,4 @@
-;;; word-count-test.el --- Tests for word-count (exercism)
+;;; word-count-test.el --- Tests for word-count (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/word-count/word-count.el
+++ b/exercises/practice/word-count/word-count.el
@@ -1,4 +1,4 @@
-;;; word-count.el --- word-count Exercise (exercism)
+;;; word-count.el --- word-count Exercise (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 


### PR DESCRIPTION
Following the Emacs Lisp Style Guide and the Emacs Lisp Coding Conventions all code should use lexical binding.

See
- https://github.com/bbatsov/emacs-lisp-style-guide#source-code-layout--organization
- https://www.gnu.org/software/emacs/manual/html_node/elisp/Coding-Conventions.html