### PR TITLE
Fix missing image in test documentation

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -35,7 +35,7 @@ code.
 Since both your code and tests are valid elisp, it is suggested to work with
 your exercise code in a buffer pane side-by side with its test, like so:
 
-![](/docs/img/dual-pane.png)
+![Screenshot showing Emacs with the Frame vertically split into two Windows](https://raw.githubusercontent.com/exercism/emacs-lisp/main/docs/img/dual-pane.png)
 
 Split the frame vertically with `C-x 3`, switch to the new window with `C-x o`,
 and open the file with `C-x C-f /path/to/file`.


### PR DESCRIPTION
I looked at [how other tracks are linking to images in their docs](https://github.com/exercism/pharo-smalltalk/search?l=Markdown&q=png) and it seems like linking to GitHub
is the way to got.

fixes #175