### PR TITLE
Add list ops exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -395,6 +395,21 @@
           "list_operations",
           "strings"
         ]
+      },
+      {
+        "slug": "list-ops",
+        "name": "List Ops",
+        "uuid": "883fdbef-ad97-4f08-8d51-d65bd91fc864",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3,
+        "topics": [
+          "filtering",
+          "functional_programming",
+          "generics",
+          "lists",
+          "loops"
+        ]
       }
     ]
   },

--- a/exercises/practice/list-ops/.docs/hints.md
+++ b/exercises/practice/list-ops/.docs/hints.md
@@ -1,0 +1,5 @@
+# Hints
+
+## General
+
+The `fold-left` and `fold-right` methods are "fold" functions, which is a concept from the functional programming world. See the Wikipedia page on folding for [general background](https://en.wikipedia.org/wiki/Fold_(higher-order_function)) and [signature/implementation hints](https://en.wikipedia.org/wiki/Fold_(higher-order_function)#Linear_folds).

--- a/exercises/practice/list-ops/.docs/instructions.append.md
+++ b/exercises/practice/list-ops/.docs/instructions.append.md
@@ -1,0 +1,3 @@
+# Hints
+
+The `fold-left` and `fold-right` methods are "fold" functions, which is a concept from the functional programming world. See the Wikipedia page on folding for [general background](https://en.wikipedia.org/wiki/Fold_(higher-order_function)) and [signature/implementation hints](https://en.wikipedia.org/wiki/Fold_(higher-order_function)#Linear_folds).

--- a/exercises/practice/list-ops/.docs/instructions.append.md
+++ b/exercises/practice/list-ops/.docs/instructions.append.md
@@ -3,6 +3,6 @@
 * `list-empty-p` (*given a list, return if the list is empty*)
 * `list-sum` (*given a list of numbers, return the sum of all elements*)
 
-# Hints
+## Hints
 
 The `fold-left` and `fold-right` methods are "fold" functions, which is a concept from the functional programming world. See the Wikipedia page on folding for [general background](https://en.wikipedia.org/wiki/Fold_(higher-order_function)) and [signature/implementation hints](https://en.wikipedia.org/wiki/Fold_(higher-order_function)#Linear_folds).

--- a/exercises/practice/list-ops/.docs/instructions.append.md
+++ b/exercises/practice/list-ops/.docs/instructions.append.md
@@ -1,3 +1,8 @@
+# Emacs Lisp Track specific functions
+
+* `list-empty-p` (*given a list, return if the list is empty*)
+* `list-sum` (*given a list of numbers, return the sum of all elements*)
+
 # Hints
 
 The `fold-left` and `fold-right` methods are "fold" functions, which is a concept from the functional programming world. See the Wikipedia page on folding for [general background](https://en.wikipedia.org/wiki/Fold_(higher-order_function)) and [signature/implementation hints](https://en.wikipedia.org/wiki/Fold_(higher-order_function)#Linear_folds).

--- a/exercises/practice/list-ops/.docs/instructions.append.md
+++ b/exercises/practice/list-ops/.docs/instructions.append.md
@@ -3,6 +3,3 @@
 * `list-empty-p` (*given a list, return if the list is empty*)
 * `list-sum` (*given a list of numbers, return the sum of all elements*)
 
-## Hints
-
-The `fold-left` and `fold-right` methods are "fold" functions, which is a concept from the functional programming world. See the Wikipedia page on folding for [general background](https://en.wikipedia.org/wiki/Fold_(higher-order_function)) and [signature/implementation hints](https://en.wikipedia.org/wiki/Fold_(higher-order_function)#Linear_folds).

--- a/exercises/practice/list-ops/.docs/instructions.md
+++ b/exercises/practice/list-ops/.docs/instructions.md
@@ -2,21 +2,16 @@
 
 Implement basic list operations.
 
-In functional languages list operations like `length`, `map`, and
-`reduce` are very common. Implement a series of basic list operations,
-without using existing functions.
+In functional languages list operations like `length`, `map`, and `reduce` are very common.
+Implement a series of basic list operations, without using existing functions.
 
-The precise number and names of the operations to be implemented will be
-track dependent to avoid conflicts with existing names, but the general
-operations you will implement include:
+The precise number and names of the operations to be implemented will be track dependent to avoid conflicts with existing names, but the general operations you will implement include:
 
-* `list-empty-p` (*given a list, return if the list is empty*)
-* `list-sum` (*given a list of numbers, return the sum of all elements*)
-* `list-append` (*given two lists, add all items in the second list to the end of the first list*);
-* `list-concatenate` (*given a series of lists, combine all items in all lists into one flattened list*);
-* `list-filter` (*given a predicate and a list, return the list of all items for which `(predicate item)` is True*);
-* `list-length` (*given a list, return the total number of items within it*);
-* `list-map` (*given a function and a list, return the list of the results of applying `(function item)` on all items*);
-* `list-foldl` (*given a function, a list, and initial accumulator, fold (reduce) each item into the accumulator from the left using `(function accumulator item))`*);
-* `list-foldr` (*given a function, a list, and an initial accumulator, fold (reduce) each item into the accumulator from the right using `(function item accumulator)`*);
-* `list-reverse` (*given a list, return a list with all the original items, but in reversed order*);
+* `append` (*given two lists, add all items in the second list to the end of the first list*);
+* `concatenate` (*given a series of lists, combine all items in all lists into one flattened list*);
+* `filter` (*given a predicate and a list, return the list of all items for which `predicate(item)` is True*);
+* `length` (*given a list, return the total number of items within it*);
+* `map` (*given a function and a list, return the list of the results of applying `function(item)` on all items*);
+* `foldl` (*given a function, a list, and initial accumulator, fold (reduce) each item into the accumulator from the left using `function(accumulator, item)`*);
+* `foldr` (*given a function, a list, and an initial accumulator, fold (reduce) each item into the accumulator from the right using `function(item, accumulator)`*);
+* `reverse` (*given a list, return a list with all the original items, but in reversed order*);

--- a/exercises/practice/list-ops/.docs/instructions.md
+++ b/exercises/practice/list-ops/.docs/instructions.md
@@ -1,0 +1,22 @@
+# Instructions
+
+Implement basic list operations.
+
+In functional languages list operations like `length`, `map`, and
+`reduce` are very common. Implement a series of basic list operations,
+without using existing functions.
+
+The precise number and names of the operations to be implemented will be
+track dependent to avoid conflicts with existing names, but the general
+operations you will implement include:
+
+* `list-empty-p` (*given a list, return if the list is empty*)
+* `list-sum` (*given a list of numbers, return the sum of all elements*)
+* `list-append` (*given two lists, add all items in the second list to the end of the first list*);
+* `list-concatenate` (*given a series of lists, combine all items in all lists into one flattened list*);
+* `list-filter` (*given a predicate and a list, return the list of all items for which `(predicate item)` is True*);
+* `list-length` (*given a list, return the total number of items within it*);
+* `list-map` (*given a function and a list, return the list of the results of applying `(function item)` on all items*);
+* `list-foldl` (*given a function, a list, and initial accumulator, fold (reduce) each item into the accumulator from the left using `(function accumulator item))`*);
+* `list-foldr` (*given a function, a list, and an initial accumulator, fold (reduce) each item into the accumulator from the right using `(function item accumulator)`*);
+* `list-reverse` (*given a list, return a list with all the original items, but in reversed order*);

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -1,10 +1,9 @@
 {
-  "blurb": "Implement basic list operations",
+  "blurb": "Implement basic list operations.",
   "authors": [
     "fap"
   ],
-  "contributors": [
-  ],
+  "contributors": [],
   "files": {
     "solution": [
       "list-ops.el"
@@ -15,7 +14,5 @@
     "example": [
       ".meta/example.el"
     ]
-  },
-  "source_url": "https://github.com/exercism/problem-specifications/tree/main/exercises/list-ops"
+  }
 }
-

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -1,0 +1,21 @@
+{
+  "blurb": "Implement basic list operations",
+  "authors": [
+    "fap"
+  ],
+  "contributors": [
+  ],
+  "files": {
+    "solution": [
+      "list-ops.el"
+    ],
+    "test": [
+      "list-ops-test.el"
+    ],
+    "example": [
+      ".meta/example.el"
+    ]
+  },
+  "source_url": "https://github.com/exercism/problem-specifications/tree/main/exercises/list-ops"
+}
+

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -1,7 +1,7 @@
 {
   "blurb": "Implement basic list operations.",
   "authors": [
-    "fap"
+    "fapdash"
   ],
   "contributors": [],
   "files": {

--- a/exercises/practice/list-ops/.meta/example.el
+++ b/exercises/practice/list-ops/.meta/example.el
@@ -4,8 +4,6 @@
 
 ;;; Code:
 
-(require 'seq)
-
 (defun list-foldl (fun list accu)
   (if (list-empty-p list)
       accu

--- a/exercises/practice/list-ops/.meta/example.el
+++ b/exercises/practice/list-ops/.meta/example.el
@@ -1,0 +1,50 @@
+;;; list-ops.el --- List Ops (exercism)  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;;; Code:
+
+(defun list-foldl (fun list accu)
+  (if (list-empty-p list)
+      accu
+    (list-foldl fun (cdr list) (funcall fun accu (car list)))))
+
+(defun list-foldr (fun list accu)
+  (if (list-empty-p list)
+      accu
+    (funcall fun (car list) (list-foldr fun (cdr list) accu))))
+
+(defun list-empty-p (list)
+  (not (car list)))
+
+(defun list-sum (list)
+  (list-foldl '+ list 0))
+
+(defun list-length (list)
+  (list-foldl (lambda (accu _elem) (1+ accu)) list 0))
+
+(defun list-append (list1 list2)
+  (list-foldr (lambda (elem accu) (cons elem accu)) list1 list2))
+
+(defun list-reverse (list)
+  (list-foldl (lambda (accu elem) (cons elem accu)) list '()))
+
+(defun list-concatenate (list1 list2 &rest LISTS)
+  (list-foldl 'list-append LISTS (list-append list1 list2)))
+
+(defun list-filter (list predicate)
+  (list-foldr (lambda (elem accu)
+                (if (funcall predicate elem)
+                    (cons elem accu)
+                  accu))
+              list
+              '()))
+
+(defun list-map (list fun)
+  (list-foldr (lambda (elem accu)
+                (cons (funcall fun elem) accu))
+              list
+              '()))
+
+(provide 'list-ops)
+;;; example.el ends here

--- a/exercises/practice/list-ops/.meta/example.el
+++ b/exercises/practice/list-ops/.meta/example.el
@@ -4,6 +4,8 @@
 
 ;;; Code:
 
+(require 'seq)
+
 (defun list-foldl (fun list accu)
   (if (list-empty-p list)
       accu
@@ -15,7 +17,7 @@
     (funcall fun (car list) (list-foldr fun (cdr list) accu))))
 
 (defun list-empty-p (list)
-  (not (car list)))
+  (zerop (length list)))
 
 (defun list-sum (list)
   (list-foldl '+ list 0))

--- a/exercises/practice/list-ops/.meta/example.el
+++ b/exercises/practice/list-ops/.meta/example.el
@@ -15,7 +15,7 @@
     (funcall fun (car list) (list-foldr fun (cdr list) accu))))
 
 (defun list-empty-p (list)
-  (zerop (length list)))
+  (null list))
 
 (defun list-sum (list)
   (list-foldl '+ list 0))

--- a/exercises/practice/list-ops/.meta/tests.toml
+++ b/exercises/practice/list-ops/.meta/tests.toml
@@ -1,0 +1,106 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[485b9452-bf94-40f7-a3db-c3cf4850066a]
+description = "append entries to a list and return the new list -> empty lists"
+
+[2c894696-b609-4569-b149-8672134d340a]
+description = "append entries to a list and return the new list -> list to empty list"
+
+[e842efed-3bf6-4295-b371-4d67a4fdf19c]
+description = "append entries to a list and return the new list -> empty list to list"
+
+[71dcf5eb-73ae-4a0e-b744-a52ee387922f]
+description = "append entries to a list and return the new list -> non-empty lists"
+
+[28444355-201b-4af2-a2f6-5550227bde21]
+description = "concatenate a list of lists -> empty list"
+
+[331451c1-9573-42a1-9869-2d06e3b389a9]
+description = "concatenate a list of lists -> list of lists"
+
+[d6ecd72c-197f-40c3-89a4-aa1f45827e09]
+description = "concatenate a list of lists -> list of nested lists"
+
+[0524fba8-3e0f-4531-ad2b-f7a43da86a16]
+description = "filter list returning only values that satisfy the filter function -> empty list"
+
+[88494bd5-f520-4edb-8631-88e415b62d24]
+description = "filter list returning only values that satisfy the filter function -> non-empty list"
+
+[1cf0b92d-8d96-41d5-9c21-7b3c37cb6aad]
+description = "returns the length of a list -> empty list"
+
+[d7b8d2d9-2d16-44c4-9a19-6e5f237cb71e]
+description = "returns the length of a list -> non-empty list"
+
+[c0bc8962-30e2-4bec-9ae4-668b8ecd75aa]
+description = "return a list of elements whose values equal the list value transformed by the mapping function -> empty list"
+
+[11e71a95-e78b-4909-b8e4-60cdcaec0e91]
+description = "return a list of elements whose values equal the list value transformed by the mapping function -> non-empty list"
+
+[613b20b7-1873-4070-a3a6-70ae5f50d7cc]
+description = "folds (reduces) the given list from the left with a function -> empty list"
+include = false
+
+[e56df3eb-9405-416a-b13a-aabb4c3b5194]
+description = "folds (reduces) the given list from the left with a function -> direction independent function applied to non-empty list"
+include = false
+
+[d2cf5644-aee1-4dfc-9b88-06896676fe27]
+description = "folds (reduces) the given list from the left with a function -> direction dependent function applied to non-empty list"
+include = false
+
+[36549237-f765-4a4c-bfd9-5d3a8f7b07d2]
+description = "folds (reduces) the given list from the left with a function -> empty list"
+reimplements = "613b20b7-1873-4070-a3a6-70ae5f50d7cc"
+
+[7a626a3c-03ec-42bc-9840-53f280e13067]
+description = "folds (reduces) the given list from the left with a function -> direction independent function applied to non-empty list"
+reimplements = "e56df3eb-9405-416a-b13a-aabb4c3b5194"
+
+[d7fcad99-e88e-40e1-a539-4c519681f390]
+description = "folds (reduces) the given list from the left with a function -> direction dependent function applied to non-empty list"
+reimplements = "d2cf5644-aee1-4dfc-9b88-06896676fe27"
+
+[aeb576b9-118e-4a57-a451-db49fac20fdc]
+description = "folds (reduces) the given list from the right with a function -> empty list"
+include = false
+
+[c4b64e58-313e-4c47-9c68-7764964efb8e]
+description = "folds (reduces) the given list from the right with a function -> direction independent function applied to non-empty list"
+include = false
+
+[be396a53-c074-4db3-8dd6-f7ed003cce7c]
+description = "folds (reduces) the given list from the right with a function -> direction dependent function applied to non-empty list"
+include = false
+
+[17214edb-20ba-42fc-bda8-000a5ab525b0]
+description = "folds (reduces) the given list from the right with a function -> empty list"
+reimplements = "aeb576b9-118e-4a57-a451-db49fac20fdc"
+
+[e1c64db7-9253-4a3d-a7c4-5273b9e2a1bd]
+description = "folds (reduces) the given list from the right with a function -> direction independent function applied to non-empty list"
+reimplements = "c4b64e58-313e-4c47-9c68-7764964efb8e"
+
+[8066003b-f2ff-437e-9103-66e6df474844]
+description = "folds (reduces) the given list from the right with a function -> direction dependent function applied to non-empty list"
+reimplements = "be396a53-c074-4db3-8dd6-f7ed003cce7c"
+
+[94231515-050e-4841-943d-d4488ab4ee30]
+description = "reverse the elements of the list -> empty list"
+
+[fcc03d1e-42e0-4712-b689-d54ad761f360]
+description = "reverse the elements of the list -> non-empty list"
+
+[40872990-b5b8-4cb8-9085-d91fc0d05d26]
+description = "reverse the elements of the list -> list of lists is not flattened"

--- a/exercises/practice/list-ops/list-ops-test.el
+++ b/exercises/practice/list-ops/list-ops-test.el
@@ -5,6 +5,16 @@
 ;;; Code:
 
 (load-file "list-ops.el")
+(declare-function list-append "list-ops.el" (list1 list2))
+(declare-function list-concatenate "list-ops.el" (list1 list2 &rest LISTS))
+(declare-function list-filter "list-ops.el" (list function))
+(declare-function list-length "list-ops.el" (list))
+(declare-function list-map "list-ops.el" (list function))
+(declare-function list-foldl "list-ops.el" (list function init))
+(declare-function list-foldr "list-ops.el" (list function init))
+(declare-function list-reverse "list-ops.el" (list))
+(declare-function list-sum "list-ops.el" (list))
+(declare-function list-empty-p "list-ops.el" (list))
 
 
 (ert-deftest append-empt-lists ()

--- a/exercises/practice/list-ops/list-ops-test.el
+++ b/exercises/practice/list-ops/list-ops-test.el
@@ -6,18 +6,101 @@
 
 (load-file "list-ops.el")
 
-;; TODO(FAP): add tests
 
-(list-length '(4 309 4))
+(ert-deftest append-empt-lists ()
+  (should (equal '() (list-append '() '()))))
 
-(list-map '(1 2 3 4 5) '1+)
 
-(list-filter '(1 2 "a" 3) 'numberp)
+(ert-deftest append-first-list-empty ()
+  (should (equal '(1 2 3 4) (list-append '() '(1 2 3 4)))))
 
-(list-reverse '(1 2 3))
-(list-append '(1 2 3) '(4 5 6))
 
-(list-concatenate '(1 2 3) '(4 5 6) '(7 8 9) '(10))
+(ert-deftest append-second-list-empty ()
+  (should (equal '(1 2 3 4) (list-append '(1 2 3 4) '()))))
+
+
+(ert-deftest append-non-empty-lists ()
+  (should (equal '(1 2 2 3 4 5) (list-append '(1 2) '(2 3 4 5)))))
+
+
+(ert-deftest concatenate-multiple-lists ()
+  (should (equal '(1 2 3 4 5 6) (list-concatenate '(1 2) '(3) '() '(4 5 6)))))
+
+
+(ert-deftest concatenate-nested-lists ()
+  (should (equal '((1) (2) (3) () (4 5 6)) (list-concatenate '((1) (2)) '((3)) '(()) '((4 5 6))))))
+
+
+(ert-deftest filter-empty-list ()
+  (should (equal '() (list-filter '() (lambda (elem) (= 1 (% elem 2)))))))
+
+
+(ert-deftest filter-matching-elements ()
+  (should (equal '(1 3 5) (list-filter '(1 2 3 5) (lambda (elem) (= 1 (% elem 2)))))))
+
+
+(ert-deftest length-empty-list ()
+  (should (equal 0 (list-length '()))))
+
+
+(ert-deftest length-with-elements ()
+  (should (equal 4 (list-length '(1 2 3 4)))))
+
+
+(ert-deftest map-increment-empty-list ()
+  (should (equal '() (list-map '() '1+))))
+
+
+(ert-deftest map-increment-elements ()
+  (should (equal '(2 4 6 8) (list-map '(1 3 5 7) '1+))))
+
+
+(ert-deftest foldl-empty-list ()
+  (should (equal 2 (list-foldl '* '() 2))))
+
+
+(ert-deftest foldl-sum-elements ()
+  (should (equal 15 (list-foldl (lambda (accu elem) (+ elem accu)) '(1 2 3 4) 5))))
+
+
+(ert-deftest foldl-floating-point-division ()
+  (should (equal 64.0 (list-foldl (lambda (accu elem) (/ elem accu)) '(1 2 3 4) 24.0))))
+
+
+(ert-deftest foldl-multiply-empty-list ()
+  (should (equal 2 (list-foldl (lambda (accu elem) (* elem accu)) '() 2))))
+
+
+(ert-deftest foldr-empty-list ()
+  (should (equal 2 (list-foldr '* '() 2))))
+
+
+(ert-deftest foldr-sum-elements ()
+  (should (equal 15 (list-foldr (lambda (elem accu) (+ elem accu)) '(1 2 3 4) 5))))
+
+
+(ert-deftest foldr-floating-point-division ()
+  (should (equal 9.0 (list-foldr (lambda (elem accu) (/ elem accu)) '(1 2 3 4) 24.0))))
+
+
+(ert-deftest foldl-multiply-empty-list ()
+  (should (equal 2 (list-foldl (lambda (elem accu) (* elem accu)) '() 2))))
+
+
+(ert-deftest foldr-multiply-empty-list ()
+  (should (equal 2 (list-foldr (lambda (elem accu) (* elem accu)) '() 2))))
+
+
+(ert-deftest reverse-empty-list ()
+  (should (equal '() (list-reverse '()))))
+
+
+(ert-deftest reverse-list-with-members ()
+  (should (equal '(7 5 3 1) (list-reverse '(1 3 5 7)))))
+
+
+(ert-deftest reverse-list-not-flattened ()
+  (should (equal '((4 5 6) () (3) (2) (1)) (list-reverse '((1) (2) (3) () (4 5 6))))))
 
 
 (provide 'list-ops-test)

--- a/exercises/practice/list-ops/list-ops-test.el
+++ b/exercises/practice/list-ops/list-ops-test.el
@@ -112,6 +112,27 @@
 (ert-deftest reverse-list-not-flattened ()
   (should (equal '((4 5 6) () (3) (2) (1)) (list-reverse '((1) (2) (3) () (4 5 6))))))
 
+;; Emacs Lisp track specific:
+
+(ert-deftest sum-empty-list ()
+  (should (equal 0 (list-sum '()))))
+
+
+(ert-deftest sum-elements ()
+  (should (equal 10 (list-sum '(1 2 3 4)))))
+
+
+(ert-deftest empty-p-empty ()
+  (should (equal t (list-empty-p '()))))
+
+
+(ert-deftest empty-p-element ()
+  (should (equal nil (list-empty-p '(1)))))
+
+
+(ert-deftest empty-p-elements ()
+  (should (equal nil (list-empty-p '(1 2 3 4)))))
+
 
 (provide 'list-ops-test)
 ;;; list-ops-test.el ends here

--- a/exercises/practice/list-ops/list-ops-test.el
+++ b/exercises/practice/list-ops/list-ops-test.el
@@ -1,0 +1,24 @@
+;;; list-ops-test.el --- Tests for List Ops (exercism)
+
+;;; Commentary:
+
+;;; Code:
+
+(load-file "list-ops.el")
+
+;; TODO(FAP): add tests
+
+(list-length '(4 309 4))
+
+(list-map '(1 2 3 4 5) '1+)
+
+(list-filter '(1 2 "a" 3) 'numberp)
+
+(list-reverse '(1 2 3))
+(list-append '(1 2 3) '(4 5 6))
+
+(list-concatenate '(1 2 3) '(4 5 6) '(7 8 9) '(10))
+
+
+(provide 'list-ops-test)
+;;; list-ops-test.el ends here

--- a/exercises/practice/list-ops/list-ops-test.el
+++ b/exercises/practice/list-ops/list-ops-test.el
@@ -1,4 +1,4 @@
-;;; list-ops-test.el --- Tests for List Ops (exercism)
+;;; list-ops-test.el --- Tests for List Ops (exercism)  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 

--- a/exercises/practice/list-ops/list-ops.el
+++ b/exercises/practice/list-ops/list-ops.el
@@ -35,8 +35,8 @@
 (defun list-map (list fun)
   (error "Delete this S-Expression and write your own implementation."))
 
+
 ;; TODO(FAP): Is it okay to activate lexical scoping? Otherwise the `fun' variables are conflicting
-;; TODO(FAP): We probably can't have more methods to implement than in the problem-description, can we?
 
 (provide 'list-ops)
 ;;; list-ops.el ends here

--- a/exercises/practice/list-ops/list-ops.el
+++ b/exercises/practice/list-ops/list-ops.el
@@ -6,36 +6,34 @@
 
 
 (defun list-foldl (fun list accu)
-  (error "Delete this S-Expression and write your own implementation."))
+  (error "Delete this S-Expression and write your own implementation"))
 
 (defun list-foldr (fun list accu)
-  (error "Delete this S-Expression and write your own implementation."))
+  (error "Delete this S-Expression and write your own implementation"))
 
 (defun list-empty-p (list)
-  (error "Delete this S-Expression and write your own implementation."))
+  (error "Delete this S-Expression and write your own implementation"))
 
 (defun list-sum (list)
-  (error "Delete this S-Expression and write your own implementation."))
+  (error "Delete this S-Expression and write your own implementation"))
 
 (defun list-length (list)
-  (error "Delete this S-Expression and write your own implementation."))
+  (error "Delete this S-Expression and write your own implementation"))
 
 (defun list-append (list1 list2)
-  (error "Delete this S-Expression and write your own implementation."))
+  (error "Delete this S-Expression and write your own implementation"))
 
 (defun list-reverse (list)
-  (error "Delete this S-Expression and write your own implementation."))
+  (error "Delete this S-Expression and write your own implementation"))
 
 (defun list-concatenate (list1 list2 &rest LISTS)
-  (error "Delete this S-Expression and write your own implementation."))
+  (error "Delete this S-Expression and write your own implementation"))
 
 (defun list-filter (list predicate)
-  (error "Delete this S-Expression and write your own implementation."))
+  (error "Delete this S-Expression and write your own implementation"))
 
 (defun list-map (list fun)
-  (error "Delete this S-Expression and write your own implementation."))
-
-
+  (error "Delete this S-Expression and write your own implementation"))
 
 (provide 'list-ops)
 ;;; list-ops.el ends here

--- a/exercises/practice/list-ops/list-ops.el
+++ b/exercises/practice/list-ops/list-ops.el
@@ -1,0 +1,42 @@
+;;; list-ops.el --- List Ops (exercism)  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;;; Code:
+
+
+(defun list-foldl (fun list accu)
+  (error "Delete this S-Expression and write your own implementation."))
+
+(defun list-foldr (fun list accu)
+  (error "Delete this S-Expression and write your own implementation."))
+
+(defun list-empty-p (list)
+  (error "Delete this S-Expression and write your own implementation."))
+
+(defun list-sum (list)
+  (error "Delete this S-Expression and write your own implementation."))
+
+(defun list-length (list)
+  (error "Delete this S-Expression and write your own implementation."))
+
+(defun list-append (list1 list2)
+  (error "Delete this S-Expression and write your own implementation."))
+
+(defun list-reverse (list)
+  (error "Delete this S-Expression and write your own implementation."))
+
+(defun list-concatenate (list1 list2 &rest LISTS)
+  (error "Delete this S-Expression and write your own implementation."))
+
+(defun list-filter (list predicate)
+  (error "Delete this S-Expression and write your own implementation."))
+
+(defun list-map (list fun)
+  (error "Delete this S-Expression and write your own implementation."))
+
+;; TODO(FAP): Is it okay to activate lexical scoping? Otherwise the `fun' variables are conflicting
+;; TODO(FAP): We probably can't have more methods to implement than in the problem-description, can we?
+
+(provide 'list-ops)
+;;; list-ops.el ends here

--- a/exercises/practice/list-ops/list-ops.el
+++ b/exercises/practice/list-ops/list-ops.el
@@ -36,7 +36,6 @@
   (error "Delete this S-Expression and write your own implementation."))
 
 
-;; TODO(FAP): Is it okay to activate lexical scoping? Otherwise the `fun' variables are conflicting
 
 (provide 'list-ops)
 ;;; list-ops.el ends here


### PR DESCRIPTION
- as noted in the problem-specification that some tracks would do that, I added a namespace to avoid conflicts with existing functions (since users will often evaluate function definitions inside of emacs they would otherwise overwrite built-in functions in their running environment)
- I've added two additional functions:
  - `list-sum`: this is just to drive the point home that you can implement functions like that very easily through the primitives implemented in this exercise
  - `list-empty-p`: I hope to bring people towards the realization that nil = empty list in Emacs Lisp, checking if the `car` and `cdr` of a list are nil will not work.

Regarding `list-empty-p` we had this discussion on slack: https://app.slack.com/client/TAN6QMALR/CAQP7JL3T/thread/CAQP7JL3T-1665705236.652139
I think there should eventually b a learning / concept exercise that explains `(equal nil '())` but for now it's better to have it in this exercise than not have it at all.