### PR TITLE
Update Emacs installation instructions

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -3,32 +3,37 @@
 Since Emacs Lisp (elisp) is the extension language for Emacs, you'll need to
 install [GNU Emacs](http://www.gnu.org/software/emacs/) first.
 
-It is recommended to get the latest Emacs, currently 24.5-1, but 24.4 or higher
-should be considered the target implementation for the exercises.
+It is recommended to get the latest Emacs, but 28.1 or higher should be considered the target implementation for the exercises.
+If you already have Emacs installed you can check the Emacs version via `M-x emacs-version RET`.
 
 ## On OS X
 The easiest way is to visit [Emacs For Mac OS X](http://emacsformacosx.com/) and download the dmg, which will
 install GNU Emacs as a packaged OS X app.
 
 Alternatives exist, such as Aquamacs (not recommended) or installing via
-Homebrew, if you prefer.
+[Homebrew](https://formulae.brew.sh/formula/emacs), if you prefer.
 
 ## On Linux
 On some distros, Emacs is already installed, since it's part of GNU.
 
 ### Ubuntu
-Prior to Ubuntu 15.04 "vivid vervet", the highest available Emacs version was
-24.3, so you'll need to use a [PPA](https://launchpad.net/ubuntu/+ppas?name_filter=emacs) or [build from source](http://linuxg.net/how-to-install-emacs-24-4-on-ubuntu-14-10-ubuntu-14-04-and-derivative-systems/) if you're on 14.10 or
-earlier.
+The currently recommended way to install the most recent Emacs is via [snap](https://snapcraft.io/emacs):
 
-Otherwise, if you're running vivid, it should be as simple as
+```
+sudo snap install emacs --classic
+```
+
+If you don't want to use snap you can also install Emacs via snap, but the version available from the Ubuntu repositories is often out of date.
+If you want to install a more recent version of Emacs via apt you'll need to use a [PPA](https://launchpad.net/ubuntu/+ppas?name_filter=emacs) or [build from source](https://www.emacswiki.org/emacs/BuildingEmacs).
+
+If you don't care about installing the latest version, it should be as simple as
 
 ```
 sudo apt-get install emacs
 ```
 
 ### Arch
-Arch currently ships with the latest Emacs 24.5-1, so run:
+Arch usually ships with the latest Emacs version, so run:
 
 ```
 sudo pacman -S emacs
@@ -41,11 +46,10 @@ Check with your distro to see what version is current, and use your package
 manager or build from source as appropriate.
 
 ### Windows
-So you've decided to install Emacs on Windows.
+To install Emacs on Windows head over to the nearest
+[FTP archive mirror](https://ftpmirror.gnu.org/emacs/windows), grab the installer (=emacs-XX.X-installer.exe=), and launch it.
+If you don't want use Emacs without installing it you can grab the file with the pattern =emacs-XX.x.zip=, unpack it and launch Emacs directly.
 
-![](http://www.zeldauniverse.net/wp-content/uploads/2012/01/83-Image-2.jpg)
-
-I've never done it, but the prevailing wisdom is that you just need to visit the
-[FTP archive](http://ftp.wayne.edu/gnu/emacs/windows/), grab the correct binary (=emacs-24.x-bin-xxx.zip=), unzip it and
-launch. YMMV, please let us know in the issues or [on Gitter](https://gitter.im/exercism/support) if this section
+### Issues
+YMMV, please let us know in the [issues](https://github.com/exercism/emacs-lisp/issues) or [on Gitter](https://gitter.im/exercism/support) if this section
 needs some love.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -48,7 +48,7 @@ manager or build from source as appropriate.
 ### Windows
 To install Emacs on Windows head over to the nearest
 [FTP archive mirror](https://ftpmirror.gnu.org/emacs/windows), grab the installer (=emacs-XX.X-installer.exe=), and launch it.
-If you don't want use Emacs without installing it you can grab the file with the pattern =emacs-XX.x.zip=, unpack it and launch Emacs directly.
+If you don't want use Emacs without installing it you can grab the file with the pattern =emacs-XX.x.zip=, unpack it and launch `bin\runemacs.exe`.
 
 ### Issues
 YMMV, please let us know in the [issues](https://github.com/exercism/emacs-lisp/issues) or [on Gitter](https://gitter.im/exercism/support) if this section

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -50,6 +50,18 @@ To install Emacs on Windows head over to the nearest
 [FTP archive mirror](https://ftpmirror.gnu.org/emacs/windows), grab the installer (=emacs-XX.X-installer.exe=), and launch it.
 If you don't want use Emacs without installing it you can grab the file with the pattern =emacs-XX.x.zip=, unpack it and launch `bin\runemacs.exe`.
 
+If you are using [MSYS2](https://www.msys2.org/) you can install the 64bits build of Emacs with
+
+```
+pacman -S mingw-w64-x86_64-emacs
+```
+
+or the 32bits build with
+
+```
+pacman -S mingw-w64-i686-emacs
+```
+
 ### Issues
 YMMV, please let us know in the [issues](https://github.com/exercism/emacs-lisp/issues) or [on Gitter](https://gitter.im/exercism/support) if this section
 needs some love.


### PR DESCRIPTION
- only mention versions in one place, where it is relevant (exercise target version), goes out of date too quickly
- recommend snap for Ubuntu as it is more up-to-date
- update Windows installation instructions to include installer
- add more links