### PR TITLE
Improve documentation of how to run tests

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,28 +1,52 @@
 # Running tests
 
 Elisp tests are run using [ERT](http://www.emacswiki.org/emacs/ErtTestLibrary), an Emacs Lisp library for regression/unit
-testing. Tests can be run several ways:
+testing. Tests can be run several ways.
 
-1. Interactively and individually, with `M-x ert RET test-name RET`
-2. Interactively and all at once, with `M-x ert RET t RET`
-3. From the terminal, in batch mode, with `emacs -batch -l ert -l my-test.el -f
-   ert-run-tests-batch-and-exit`
-4. Other options can be found in the docs, `C-h i m ert RET`
+To run the tests interactively from within Emacs:
+
+1. Open test file, `M-x eval-buffer RET`
+2. Interactively and individually, with `M-x ert RET test-name RET`
+3. Interactively and all at once, with `M-x ert RET t RET`
+   Note that this will run all tests currently loaded into Emacs!
+4. Rerun `M-x eval-buffer RET` before testing whenever you've made changes
+
+To only execute the tests in the current buffer you can add this to your `.emacs` or `init.el`:
+
+```elisp
+(defun my-eval-and-run-all-tests-in-buffer ()
+  "Delete all loaded tests from the runtime, evaluate the current buffer and run all loaded tests with ert."
+  (interactive)
+  (ert-delete-all-tests)
+  (eval-buffer)
+  (ert 't))
+```
+
+After restarting Emacs:
+
+1. Open test file
+2. `M-x my-eval-and-run-all-tests-in-buffer RET`
 
 Interactive testing is great while you're working on an exercise, but batch mode
 testing is preferable for when you want to check that an exercise is ready for
-submission. The above command is a bit unwieldy, so if you like:
+submission.
+
+To run run all tests from the terminal, in batch mode, execute `emacs -batch -l ert -l *-test.el -f ert-run-tests-batch-and-exit`
+
+The above command is a bit unwieldy, so if you like:
 
 1. Create a file on your `$PATH` (probably in `~/bin`) called `ert-run`
 2. The contents of the file should be as follows:
    ```sh
-   #!/usr/bin/sh
+   #!/usr/bin/env sh
    emacs -batch -l ert -l $1 -f ert-run-tests-batch-and-exit
    ```
 3. Make the file executable with `chmod +x ert-run`
 
-You should be able to simply call `ert-run exercise-test.el` and run the tests
+You should be able to simply call `ert-run *-test.el` and run the tests
 in batch mode.
+
+Other options can be found in the docs, `C-h i m ert RET`.
 
 ## Working on exercises
 Since Emacs is, itself, an elisp interpreter, your working code is always in its

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -1,9 +1,48 @@
 # Tests
 
-Tests can be run several ways:
+Tests can be run several ways.
+
+## Interactively from within Emacs
 
 1. Open test file, `M-x eval-buffer RET`
 2. Interactively and individually, with `M-x ert RET test-name RET`
 3. Interactively and all at once, with `M-x ert RET t RET`
-4. From the terminal, in batch mode, with `emacs -batch -l ert -l my-test.el -f ert-run-tests-batch-and-exit`
-5. Other options can be found in the docs, `C-h i m ert RET`
+   Note that this will run all tests currently loaded into Emacs!
+4. Rerun `M-x eval-buffer RET` before testing whenever you've made changes
+
+To only execute the tests in the current buffer you can add this to your `.emacs` or `init.el`:
+
+```elisp
+(defun my-eval-and-run-all-tests-in-buffer ()
+  "Deletes all loaded tests from the runtime, evaluates the current buffer and runs all loaded tests with ert."
+  (interactive)
+  (ert-delete-all-tests)
+  (eval-buffer)
+  (ert 't))
+```
+
+After restarting Emacs:
+
+1. Open test file
+2. `M-x my-eval-and-run-all-tests-in-buffer RET`
+
+## From the terminal
+
+To run run all tests from the terminal, in batch mode, execute `emacs -batch -l ert -l *-test.el -f ert-run-tests-batch-and-exit`
+
+The above command is a bit unwieldy, so if you like:
+
+1. Create a file on your `$PATH` (probably in `~/bin`) called `ert-run`
+2. The contents of the file should be as follows:
+   ```sh
+   #!/usr/bin/env sh
+   emacs -batch -l ert -l $1 -f ert-run-tests-batch-and-exit
+   ```
+3. Make the file executable with `chmod +x ert-run`
+
+You should be able to simply call `ert-run *-test.el` and run the tests
+in batch mode.
+
+## Other options
+
+Other options can be found in the docs, `C-h i m ert RET`.


### PR DESCRIPTION
- sync information between test doc files
- tell people to run `eval-buffer` in `TESTS.md`
- tell people that they have to reload the test file after making changes
- add Emacs Lisp function that reloads changes and only runs tests from the current buffer
- use `/usr/bin/env` in bash script for better portability

closes #205