### PR TITLE
Update help resources

### DIFF
--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -7,7 +7,7 @@
 3. IRC - there are [Libera.Chat](https://libera.chat/) channels for `#emacs`, `#org-mode`, and many Emacs
    packages, and many helpful folks around. And with emacs, IRC is as close as
    `M-x erc`.
-4. Matrix - on [Matrix](https://matrix.org/) there are rooms for [emacs](https://matrix.to/#/#emacs:matrix.org), [org-mode](https://matrix.to/#/#org-mode:matrix.org), and other Emacs packages on.
+4. Matrix - on [Matrix](https://matrix.org/) there are rooms for [emacs](https://matrix.to/#/#emacs:matrix.org), [org-mode](https://matrix.to/#/#org-mode:matrix.org), and other Emacs packages.
    You can [join the Emacs Matrix space](https://matrix.to/#/#emacs-space:matrix.org) to get an overview of the available channels.
    To join Matrix from within Emacs you can use the [Ement.el](https://github.com/alphapapa/ement.el) package.
 5. [StackOverflow](http://stackoverflow.com/questions/tagged/elisp) and [Emacs StackExchange](https://emacs.stackexchange.com/questions/tagged/elisp) can be used to search for your problem and see if it has been answered already. You can also ask and answer questions.

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -4,6 +4,10 @@
 
 1. [The Emacs Wiki](http://emacswiki.org/) is invaluable. Spend lots of time here.
 2. [The Emacs Editor](http://www.gnu.org/software/emacs/manual/html_node/emacs/index.html) is the official manual for GNU Emacs.
-3. IRC - there are [freenode](https://freenode.net/) channels for `#emacs`, `#prelude`, and many Emacs
+3. IRC - there are [Libera.Chat](https://libera.chat/) channels for `#emacs`, `#org-mode`, and many Emacs
    packages, and many helpful folks around. And with emacs, IRC is as close as
    `M-x erc`.
+4. Matrix - on [Matrix](https://matrix.org/) there are rooms for [emacs](https://matrix.to/#/#emacs:matrix.org), [org-mode](https://matrix.to/#/#org-mode:matrix.org), and other Emacs packages on.
+   You can [join the Emacs Matrix space](https://matrix.to/#/#emacs-space:matrix.org) to get an overview of the available channels.
+   To join Matrix from within Emacs you can use the [Ement.el](https://github.com/alphapapa/ement.el) package.
+5. [StackOverflow](http://stackoverflow.com/questions/tagged/elisp) and [Emacs StackExchange](https://emacs.stackexchange.com/questions/tagged/elisp) can be used to search for your problem and see if it has been answered already. You can also ask and answer questions.

--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -4,7 +4,10 @@ To get help if you're having trouble, you can use one of the following resources
 
 - [The Emacs Wiki](http://emacswiki.org/) is invaluable. Spend lots of time here.
 - [The Emacs Editor](http://www.gnu.org/software/emacs/manual/html_node/emacs/index.html) is the official manual for GNU Emacs.
-- IRC - there are [freenode](https://freenode.net/) channels for `#emacs`, `#prelude`, and many Emacs
+- IRC - there are [Libera.Chat](https://libera.chat/) channels for `#emacs`, `#org-mode`, and many Emacs
   packages, and many helpful folks around. And with emacs, IRC is as close as
   `M-x erc`.
-- [StackOverflow](http://stackoverflow.com/questions/tagged/elisp) can be used to search for your problem and see if it has been answered already. You can also ask and answer questions.
+- Matrix - on [Matrix](https://matrix.org/) there are rooms for [emacs](https://matrix.to/#/#emacs:matrix.org), [org-mode](https://matrix.to/#/#org-mode:matrix.org), and other Emacs packages on.
+  You can [join the Emacs Matrix space](https://matrix.to/#/#emacs-space:matrix.org) to get an overview of the available channels.
+  To join Matrix from within Emacs you can use the [Ement.el](https://github.com/alphapapa/ement.el) package.
+- [StackOverflow](http://stackoverflow.com/questions/tagged/elisp) and [Emacs StackExchange](https://emacs.stackexchange.com/questions/tagged/elisp) can be used to search for your problem and see if it has been answered already. You can also ask and answer questions.

--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -7,7 +7,7 @@ To get help if you're having trouble, you can use one of the following resources
 - IRC - there are [Libera.Chat](https://libera.chat/) channels for `#emacs`, `#org-mode`, and many Emacs
   packages, and many helpful folks around. And with emacs, IRC is as close as
   `M-x erc`.
-- Matrix - on [Matrix](https://matrix.org/) there are rooms for [emacs](https://matrix.to/#/#emacs:matrix.org), [org-mode](https://matrix.to/#/#org-mode:matrix.org), and other Emacs packages on.
+- Matrix - on [Matrix](https://matrix.org/) there are rooms for [emacs](https://matrix.to/#/#emacs:matrix.org), [org-mode](https://matrix.to/#/#org-mode:matrix.org), and other Emacs packages.
   You can [join the Emacs Matrix space](https://matrix.to/#/#emacs-space:matrix.org) to get an overview of the available channels.
   To join Matrix from within Emacs you can use the [Ement.el](https://github.com/alphapapa/ement.el) package.
 - [StackOverflow](http://stackoverflow.com/questions/tagged/elisp) and [Emacs StackExchange](https://emacs.stackexchange.com/questions/tagged/elisp) can be used to search for your problem and see if it has been answered already. You can also ask and answer questions.


### PR DESCRIPTION
- recommend libera.chat instead of freenode
- reference Matrix channels
- add Emacs StackExchange to the shared exercise docs
- also recommend StackOverflow and StackExchange in the online docs