### PR TITLE
Remove reference to Gitter

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -61,7 +61,3 @@ or the 32bits build with
 ```
 pacman -S mingw-w64-i686-emacs
 ```
-
-### Issues
-YMMV, please let us know in the [issues](https://github.com/exercism/emacs-lisp/issues) or [on Gitter](https://gitter.im/exercism/support) if this section
-needs some love.

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -7,5 +7,3 @@
 3. IRC - there are [freenode](https://freenode.net/) channels for `#emacs`, `#prelude`, and many Emacs
    packages, and many helpful folks around. And with emacs, IRC is as close as
    `M-x erc`.
-4. [Exercism Support](https://gitter.im/exercism/support) Gitter chat is also a good place to get help from the
-   exercism community.

--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -7,6 +7,4 @@ To get help if you're having trouble, you can use one of the following resources
 - IRC - there are [freenode](https://freenode.net/) channels for `#emacs`, `#prelude`, and many Emacs
   packages, and many helpful folks around. And with emacs, IRC is as close as
   `M-x erc`.
-- [Exercism Support](https://gitter.im/exercism/support) Gitter chat is also a good place to get help from the
-  exercism community.
 - [StackOverflow](http://stackoverflow.com/questions/tagged/elisp) can be used to search for your problem and see if it has been answered already. You can also ask and answer questions.


### PR DESCRIPTION
The Exerism Forum (https://forum.exercism.org/) has now made Gitter redundant.
We're directing everyone there.
