### PR TITLE
Fix typo introduced in 5031301

### DIFF
--- a/exercises/practice/hello-world/hello-world.el
+++ b/exercises/practice/hello-world/hello-world.el
@@ -1,4 +1,9 @@
-(defun hello ()  -*- lexical-binding: t; -*-
+;;; hello-world.el --- Hello World exercise (exercism)  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+(defun hello ()
   "Goodbye, Mars!")
 
 (provide 'hello-world)
+;;; hello-world.el ends here


### PR DESCRIPTION
Emacs is very unhappy about this complaining about "void-variable (-*-)" for a very valid reason.  I looked through the rest of commit 5031301 and this seems to be the only typo.

I'm going to mention @ErikSchierboom and @fapdash since they where responsible for this change.  Not to be mean, just to let them know.  Everyone makes mistakes :)

Thanks everyone for making this course!  I can't wait to get past the first exercise :P