### PR TITLE
Remove duplicate test function from list-ops-test.el (#225)

### DIFF
--- a/exercises/practice/list-ops/list-ops-test.el
+++ b/exercises/practice/list-ops/list-ops-test.el
@@ -93,10 +93,6 @@
   (should (equal 9.0 (list-foldr (lambda (elem accu) (/ elem accu)) '(1 2 3 4) 24.0))))
 
 
-(ert-deftest foldl-multiply-empty-list ()
-  (should (equal 2 (list-foldl (lambda (elem accu) (* elem accu)) '() 2))))
-
-
 (ert-deftest foldr-multiply-empty-list ()
   (should (equal 2 (list-foldr (lambda (elem accu) (* elem accu)) '() 2))))
 


### PR DESCRIPTION
If there is a duplicate test present when running ERT on a whole file from the command line, it will complain loudly and not even attempt to run any of the tests.