### PR TITLE
Periodically check if exercises are in sync via GH Action

### DIFF
--- a/.github/configlet-sync-issue.md
+++ b/.github/configlet-sync-issue.md
@@ -1,0 +1,12 @@
+---
+title: Out of sync practice exercises
+---
+
+Out of sync practice exercises have been detected:
+
+Command: `configlet sync --tests --docs --metadata --filepaths`
+
+Output:
+```
+{{ env.SYNC_OUTPUT }}
+```

--- a/.github/workflows/configlet-sync.yml
+++ b/.github/workflows/configlet-sync.yml
@@ -1,0 +1,36 @@
+name: Configlet Sync
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  configlet:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+
+      - name: Fetch configlet
+        uses: exercism/github-actions/configlet-ci@main
+
+      - name: Configlet Sync
+        id: sync
+        shell: bash {0}
+        run: |
+          echo "SYNC_OUTPUT<<EOF" >> $GITHUB_ENV
+          configlet sync --tests --docs --metadata --filepaths >> $GITHUB_ENV
+          exit_code=$?
+          echo "EOF" >> $GITHUB_ENV
+          exit $exit_code
+
+      - name: Create issue
+        if: ${{ failure() }}
+        uses: JasonEtco/create-an-issue@1a16035489d05041b9af40b970f02e301c52ffba # v2.8.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/configlet-sync-issue.md
+          update_existing: true


### PR DESCRIPTION
Found this action on the common-lisp track and it seems very useful to keep a track healthy and up-to-date.

See https://github.com/exercism/common-lisp/blob/de5fadcd239987563f43b67c23863afe485a954d/.github/workflows/configlet-sync.yml

I tested the action on my fork, see
- https://github.com/fapdash/exercism--emacs-lisp/actions/runs/3503328179/jobs/5868317315 (failure is expected since the exercises are currently not in sync)
- https://github.com/fapdash/exercism--emacs-lisp/issues/3