### PR TITLE
Sync tests of gigasecond exercise

### DIFF
--- a/exercises/practice/gigasecond/.meta/tests.toml
+++ b/exercises/practice/gigasecond/.meta/tests.toml
@@ -23,3 +23,7 @@ description = "full time specified"
 
 [09d4e30e-728a-4b52-9005-be44a58d9eba]
 description = "full time with day roll-over"
+
+[fcec307c-7529-49ab-b0fe-20309197618a]
+description = "does not mutate the input"
+include = false


### PR DESCRIPTION
Since we are not using a mutable date time type as input we can skip this test.