### PR TITLE
fix second 'input-base-is-negative' test to be 'negative-digit'

### DIFF
--- a/exercises/practice/all-your-base/all-your-base-test.el
+++ b/exercises/practice/all-your-base/all-your-base-test.el
@@ -68,7 +68,7 @@
   (should-error (rebase '(1) -2 10)))
 
 
-(ert-deftest input-base-is-negative ()
+(ert-deftest negative-digit ()
   (should-error (rebase '(1 -1 1 0 1 0) 2 10)))
 
 


### PR DESCRIPTION
The exercise from #260 had the `negative-digit` (according to the Python track) test with the duplicate `input-base-is-negative` name.