### PR TITLE
Fix failing configlet-sync GHA workflow

### DIFF
--- a/.github/workflows/configlet-sync.yml
+++ b/.github/workflows/configlet-sync.yml
@@ -15,6 +15,11 @@ jobs:
 
       - name: Fetch configlet
         uses: exercism/github-actions/configlet-ci@main
+        # GITHUB_TOKEN is not set when we run the fetch script, because we're in
+        # a composite action. Set GH_TOKEN so that `gh release download` can
+        # make authenticated requests (it fails otherwise).
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Configlet Sync
         id: sync


### PR DESCRIPTION
The configlet-ci action switched to using the gh cli command and needs to have `GH_TOKEN` set to work now.

This sets the token in the same way as upstream does it at https://github.com/exercism/github-actions/blob/a3f83169a9218d28cae3c04d70522f0519d92d46/.github/workflows/configlet.yml#L29-L33

Previous error was:

> The GH_TOKEN environment variable is not set

See https://github.com/exercism/github-actions/pull/107 for more context