### PR TITLE
Rename is-pangram function to pangramp

### DIFF
--- a/exercises/practice/pangram/.meta/example.el
+++ b/exercises/practice/pangram/.meta/example.el
@@ -5,7 +5,7 @@
 ;;; Code:
 (require 'cl-lib)
 
-(defun is-pangram (phrase)
+(defun pangramp (phrase)
   "Determine if a given phrase is a pangram."
   (let ((alphabet "abcdefghijklmnopqrstuvwxyz"))
         (cl-every

--- a/exercises/practice/pangram/pangram-test.el
+++ b/exercises/practice/pangram/pangram-test.el
@@ -6,37 +6,37 @@
 ;;; Code:
 
 (load-file "pangram.el")
-(declare-function is-pangram "pangram.el" (phrase))
+(declare-function pangramp "pangram.el" (phrase))
 
 (ert-deftest sentence-empty ()
-  (should (equal nil (is-pangram ""))))
+  (should (equal nil (pangramp ""))))
 
 (ert-deftest recognizes-a-perfect-lower-case-pangram ()
-  (should (equal t (is-pangram "abcdefghijklmnopqrstuvwxyz"))))
+  (should (equal t (pangramp "abcdefghijklmnopqrstuvwxyz"))))
 
 (ert-deftest  pangram-with-only-lower-case ()
-  (should (equal t (is-pangram "the quick brown fox jumps over the lazy dog"))))
+  (should (equal t (pangramp "the quick brown fox jumps over the lazy dog"))))
 
 (ert-deftest missing-character-x ()
-  (should (equal nil (is-pangram "a quick movement of the enemy will jeopardize five gunboats"))))
+  (should (equal nil (pangramp "a quick movement of the enemy will jeopardize five gunboats"))))
 
 (ert-deftest missing-another-character-eg-h ()
-  (should (equal nil (is-pangram "five boxing wizards jump quickly at it"))))
+  (should (equal nil (pangramp "five boxing wizards jump quickly at it"))))
 
 (ert-deftest  pangram-with-underscores ()
-  (should (equal t (is-pangram "the_quick_brown_fox_jumps_over_the_lazy_dog"))))
+  (should (equal t (pangramp "the_quick_brown_fox_jumps_over_the_lazy_dog"))))
 
 (ert-deftest  pangram-with-numbers ()
-  (should (equal t (is-pangram "the 1 quick brown fox jumps over the 2 lazy dogs"))))
+  (should (equal t (pangramp "the 1 quick brown fox jumps over the 2 lazy dogs"))))
 
 (ert-deftest  missing-letters-replaced-by-numbers ()
-  (should (equal nil (is-pangram "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog"))))
+  (should (equal nil (pangramp "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog"))))
 
 (ert-deftest  pangram-with-mixed-case-and-punctuation ()
-  (should (equal t (is-pangram "\"Five quacking Zephyrs jolt my wax bed.\""))))
+  (should (equal t (pangramp "\"Five quacking Zephyrs jolt my wax bed.\""))))
 
 (ert-deftest  a-m-and-A-M-are-26-different-characters-but-not-a-pangram ()
-  (should (equal nil (is-pangram "abcdefghijklm ABCDEFGHIJKLM"))))
+  (should (equal nil (pangramp "abcdefghijklm ABCDEFGHIJKLM"))))
 
 (provide 'pangram-test)
 ;;; pagram-test.el ends here

--- a/exercises/practice/pangram/pangram.el
+++ b/exercises/practice/pangram/pangram.el
@@ -2,7 +2,7 @@
 
 ;;; Commentary:
 
-(defun is-pangram (phrase)
+(defun pangramp (phrase)
 ;;; Code:
 )
 


### PR DESCRIPTION
## Description:

With this PR I'm renaming the function `is-pangram` as `pangramp`. 

Why? Because the latter is more Lispy than the former.

Reference:

* [bbatsov/emacs-lisp-style-guide](https://github.com/bbatsov/emacs-lisp-style-guide)

> The names of predicate methods (methods that return a boolean value) should end in a `p` if it’s a single-word name and a `-p` if it’s a multi-word name (e.g., `evenp` and `buffer-live-p`).
>
> ```elisp
> ;; good
> (defun palindromep ...)
> (defun only-one-p ...)
> 
> ;; bad
> (defun palindrome? ...) ; Scheme style
> (defun is-palindrome ...) ; Java style
> ```