### PR TITLE
Upgrade CI test run to Emacs 28.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: purcell/setup-emacs@ac5a5667ef01c598f55e66e0b0abdad5d825daf8
         with:
-          version: 28.1
+          version: 28.2
 
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 


### PR DESCRIPTION
Brings the CI test run in sync with the test runner.

Should be merged in sync with https://github.com/exercism/emacs-lisp-test-runner/pull/58.