### PR TITLE
Fix stub generation for tests in practice exercise generator

### DIFF
--- a/tools/templates/exercises/practice/test.mustache
+++ b/tools/templates/exercises/practice/test.mustache
@@ -9,7 +9,7 @@
 {{#tests}}
 
 
-(defun {{test-name}} ()
+(ert-deftest {{test-name}} ()
   ;; Function under test: {{function-under-test}}
   ;; Input: {{{input}}}
   ;; Expected: {{{expected}}}


### PR DESCRIPTION
- need to use `ert-deftest` for tests instead of `defun`