### PR TITLE
Add reverse-string practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -445,6 +445,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1
+      },
+      {
+        "slug": "reverse-string",
+        "name": "Reverse String",
+        "uuid": "59c6319b-2799-4e4c-bef1-e28626878446",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/reverse-string/.docs/instructions.md
+++ b/exercises/practice/reverse-string/.docs/instructions.md
@@ -1,0 +1,7 @@
+# Instructions
+
+Reverse a string
+
+For example:
+input: "cool"
+output: "looc"

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "fapdash"
+  ],
+  "files": {
+    "solution": [
+      "reverse-string.el"
+    ],
+    "test": [
+      "reverse-string-test.el"
+    ],
+    "example": [
+      ".meta/example.el"
+    ]
+  },
+  "blurb": "Reverse a string.",
+  "source": "Introductory challenge to reverse an input string",
+  "source_url": "https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb"
+}

--- a/exercises/practice/reverse-string/.meta/example.el
+++ b/exercises/practice/reverse-string/.meta/example.el
@@ -1,0 +1,14 @@
+;;; reverse-string.el --- Reverse String (exercism)  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;;; Code:
+
+
+(defun reverse-string (value)
+  (error
+   "Delete this S-Expression and write your own implementation"))
+
+
+(provide 'reverse-string)
+;;; reverse-string.el ends here

--- a/exercises/practice/reverse-string/.meta/example.el
+++ b/exercises/practice/reverse-string/.meta/example.el
@@ -6,8 +6,7 @@
 
 
 (defun reverse-string (value)
-  (error
-   "Delete this S-Expression and write your own implementation"))
+  (reverse value))
 
 
 (provide 'reverse-string)

--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -1,0 +1,28 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[c3b7d806-dced-49ee-8543-933fd1719b1c]
+description = "an empty string"
+
+[01ebf55b-bebb-414e-9dec-06f7bb0bee3c]
+description = "a word"
+
+[0f7c07e4-efd1-4aaa-a07a-90b49ce0b746]
+description = "a capitalized word"
+
+[71854b9c-f200-4469-9f5c-1e8e5eff5614]
+description = "a sentence with punctuation"
+
+[1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c]
+description = "a palindrome"
+
+[b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c]
+description = "an even-sized word"

--- a/exercises/practice/reverse-string/reverse-string-test.el
+++ b/exercises/practice/reverse-string/reverse-string-test.el
@@ -1,0 +1,37 @@
+;;; reverse-string-test.el --- Reverse String (exercism)  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;;; Code:
+
+
+(load-file "reverse-string.el")
+(declare-function reverse-string "reverse-string.el" (value))
+
+
+(ert-deftest an-empty-string ()
+  (should (string= (reverse-string "") "")))
+
+
+(ert-deftest a-word ()
+  (should (string= (reverse-string "robot") "tobor")))
+
+
+(ert-deftest a-capitalized-word ()
+  (should (string= (reverse-string "Ramen") "nemaR")))
+
+
+(ert-deftest a-sentence-with-punctuation ()
+  (should (string= (reverse-string "I'm hungry!") "!yrgnuh m'I")))
+
+
+(ert-deftest a-palindrome ()
+  (should (string= (reverse-string "racecar") "racecar")))
+
+
+(ert-deftest an-even-sized-word ()
+  (should (string= (reverse-string "drawer") "reward")))
+
+
+(provide 'reverse-string-test)
+;;; reverse-string-test.el ends here

--- a/exercises/practice/reverse-string/reverse-string.el
+++ b/exercises/practice/reverse-string/reverse-string.el
@@ -1,0 +1,13 @@
+;;; reverse-string.el --- Reverse String (exercism)  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;;; Code:
+
+
+(defun reverse-string (value)
+  (reverse value))
+
+
+(provide 'reverse-string)
+;;; reverse-string.el ends here

--- a/exercises/practice/reverse-string/reverse-string.el
+++ b/exercises/practice/reverse-string/reverse-string.el
@@ -6,7 +6,8 @@
 
 
 (defun reverse-string (value)
-  (reverse value))
+  (error
+   "Delete this S-Expression and write your own implementation"))
 
 
 (provide 'reverse-string)


### PR DESCRIPTION
The canonical data defines the function to implement as `reverse` but it got changed to `reverse-string` so Emacs users don't overwrite the built in `reverse` function while doing REPL driven programming.