### PR TITLE
Add flatten-array practice exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -445,6 +445,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1
+      },
+      {
+        "slug": "flatten-array",
+        "name": "Flatten Array",
+        "uuid": "66f266a8-9c5c-4aad-8a27-92810b288a2b",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 6
       }
     ]
   },

--- a/exercises/practice/flatten-array/.docs/instructions.md
+++ b/exercises/practice/flatten-array/.docs/instructions.md
@@ -1,0 +1,11 @@
+# Instructions
+
+Take a nested list and return a single flattened list with all values except nil/null.
+
+The challenge is to write a function that accepts an arbitrarily-deep nested list-like structure and returns a flattened structure without any nil/null values.
+
+For example:
+
+input: [1,[2,3,null,4],[null],5]
+
+output: [1,2,3,4,5]

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "fapdash"
+  ],
+  "files": {
+    "solution": [
+      "flatten-array.el"
+    ],
+    "test": [
+      "flatten-array-test.el"
+    ],
+    "example": [
+      ".meta/example.el"
+    ]
+  },
+  "blurb": "Take a nested list and return a single list with all values except nil/null.",
+  "source": "Interview Question",
+  "source_url": "https://reference.wolfram.com/language/ref/Flatten.html"
+}

--- a/exercises/practice/flatten-array/.meta/example.el
+++ b/exercises/practice/flatten-array/.meta/example.el
@@ -1,0 +1,13 @@
+;;; flatten-array.el --- Flatten Array (exercism)  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;;; Code:
+
+
+(defun list-flatten (list)
+  (flatten-tree list))
+
+
+(provide 'flatten-array)
+;;; flatten-array.el ends here

--- a/exercises/practice/flatten-array/.meta/tests.toml
+++ b/exercises/practice/flatten-array/.meta/tests.toml
@@ -1,0 +1,43 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[8c71dabd-da60-422d-a290-4a571471fb14]
+description = "empty"
+
+[d268b919-963c-442d-9f07-82b93f1b518c]
+description = "no nesting"
+
+[3f15bede-c856-479e-bb71-1684b20c6a30]
+description = "flattens a nested array"
+
+[c84440cc-bb3a-48a6-862c-94cf23f2815d]
+description = "flattens array with just integers present"
+
+[d3d99d39-6be5-44f5-a31d-6037d92ba34f]
+description = "5 level nesting"
+
+[d572bdba-c127-43ed-bdcd-6222ac83d9f7]
+description = "6 level nesting"
+
+[0705a8e5-dc86-4cec-8909-150c5e54fa9c]
+description = "null values are omitted from the final result"
+
+[c6cf26de-8ccd-4410-84bd-b9efd88fd2bc]
+description = "consecutive null values at the front of the list are omitted from the final result"
+
+[382c5242-587e-4577-b8ce-a5fb51e385a1]
+description = "consecutive null values in the middle of the list are omitted from the final result"
+
+[ef1d4790-1b1e-4939-a179-51ace0829dbd]
+description = "6 level nest list with null values"
+
+[85721643-705a-4150-93ab-7ae398e2942d]
+description = "all values in nested list are null"

--- a/exercises/practice/flatten-array/flatten-array-test.el
+++ b/exercises/practice/flatten-array/flatten-array-test.el
@@ -1,0 +1,74 @@
+;;; flatten-array-test.el --- Flatten Array (exercism)  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;;; Code:
+
+
+(load-file "flatten-array.el")
+(declare-function list-flatten "flatten-array.el" (array))
+
+
+(ert-deftest empty ()
+  (should (equal (list-flatten '()) '())))
+
+
+(ert-deftest no-nesting ()
+  (should (equal (list-flatten '(0 1 2)) '(0 1 2))))
+
+
+(ert-deftest flattens-a-nested-array ()
+  (should (equal (list-flatten '((()))) '())))
+
+
+(ert-deftest flattens-array-with-just-integers-present ()
+  (should
+   (equal (list-flatten '(1 (2 3 4 5 6 7) 8)) '(1 2 3 4 5 6 7 8))))
+
+
+(ert-deftest 5-level-nesting ()
+  (should
+   (equal
+    (list-flatten '(0 2 ((2 3) 8 100 4 (((50)))) -2))
+    '(0 2 2 3 8 100 4 50 -2))))
+
+
+(ert-deftest 6-level-nesting ()
+  (should
+   (equal
+    (list-flatten '(1 (2 ((3)) (4 ((5))) 6 7) 8))
+    '(1 2 3 4 5 6 7 8))))
+
+
+(ert-deftest null-values-are-omitted-from-the-final-result ()
+  (should (equal (list-flatten '(1 2 nil)) '(1 2))))
+
+
+(ert-deftest
+    consecutive-null-values-at-the-front-of-the-list-are-omitted-from-the-final-result
+    ()
+  (should (equal (list-flatten '(nil nil 3)) '(3))))
+
+
+(ert-deftest
+    consecutive-null-values-in-the-middle-of-the-list-are-omitted-from-the-final-result
+    ()
+  (should (equal (list-flatten '(1 nil nil 4)) '(1 4))))
+
+
+(ert-deftest 6-level-nest-list-with-null-values ()
+  (should
+   (equal
+    (list-flatten
+     '(0 2 ((2 3) 8 ((100)) nil ((nil))) -2))
+    '(0 2 2 3 8 100 -2))))
+
+
+(ert-deftest all-values-in-nested-list-are-null ()
+  (should
+   (equal
+    (list-flatten '(nil (((nil))) nil nil ((nil nil) nil) nil)) '())))
+
+
+(provide 'flatten-array-test)
+;;; flatten-array-test.el ends here

--- a/exercises/practice/flatten-array/flatten-array.el
+++ b/exercises/practice/flatten-array/flatten-array.el
@@ -1,0 +1,14 @@
+;;; flatten-array.el --- Flatten Array (exercism)  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;;; Code:
+
+
+(defun list-flatten (list)
+  (error
+   "Delete this S-Expression and write your own implementation"))
+
+
+(provide 'flatten-array)
+;;; flatten-array.el ends here


### PR DESCRIPTION
- reverse lists instead of arrays since they are the more common data structure in Emacs Lisp
- use `list-flatten` to make it extra clear that lists are the expected input
- use `list-flatten` instead of `flatten-list` to avoid overwriting built-in Emacs function (alias)