### PR TITLE
feat: Add exercise Collatz Conjecture (closes #310)

### DIFF
--- a/config.json
+++ b/config.json
@@ -102,6 +102,17 @@
         ]
       },
       {
+        "slug": "collatz-conjecture",
+        "name": "Collatz Conjecture",
+        "uuid": "1eadc0d0-2086-4ab4-a53c-386933bf30f8",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2,
+        "topics": [
+          "math"
+        ]
+      },
+      {
         "slug": "darts",
         "name": "Darts",
         "uuid": "ca189b4e-713d-4722-b21e-c07d1b975b58",

--- a/exercises/practice/collatz-conjecture/.docs/instructions.md
+++ b/exercises/practice/collatz-conjecture/.docs/instructions.md
@@ -1,0 +1,29 @@
+# Instructions
+
+The Collatz Conjecture or 3x+1 problem can be summarized as follows:
+
+Take any positive integer n.
+If n is even, divide n by 2 to get n / 2.
+If n is odd, multiply n by 3 and add 1 to get 3n + 1.
+Repeat the process indefinitely.
+The conjecture states that no matter which number you start with, you will always reach 1 eventually.
+
+Given a number n, return the number of steps required to reach 1.
+
+## Examples
+
+Starting with n = 12, the steps would be as follows:
+
+0. 12
+1. 6
+2. 3
+3. 10
+4. 5
+5. 16
+6. 8
+7. 4
+8. 2
+9. 1
+
+Resulting in 9 steps.
+So for input n = 12, the return value would be 9.

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "keiravillekode"
+  ],
+  "files": {
+    "solution": [
+      "collatz-conjecture.el"
+    ],
+    "test": [
+      "collatz-conjecture-test.el"
+    ],
+    "example": [
+      ".meta/example.el"
+    ]
+  },
+  "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture.",
+  "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",
+  "source_url": "https://en.wikipedia.org/wiki/3x_%2B_1_problem"
+}

--- a/exercises/practice/collatz-conjecture/.meta/example.el
+++ b/exercises/practice/collatz-conjecture/.meta/example.el
@@ -1,0 +1,21 @@
+;;; collatz-conjecture.el --- Collatz Conjecture (exercism)  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;;; Code:
+
+(require 'cl-lib)
+
+(defun steps (number)
+  "Count the steps to reach 1 using the Collatz conjecture."
+  (unless (< 0 number) (error "Only positive integers are allowed"))
+  (cl-labels
+    ((recur (n count)
+      (cond
+        ((= 0 (mod n 2)) (funcall #'recur (/ n 2) (+ 1 count)))
+        ((< 1 n) (funcall #'recur (+ 1 (* 3 n)) (+ 1 count)))
+        (t count))))
+    (funcall #'recur number 0)))
+
+(provide 'collatz-conjecture)
+;;; collatz-conjecture.el ends here

--- a/exercises/practice/collatz-conjecture/.meta/tests.toml
+++ b/exercises/practice/collatz-conjecture/.meta/tests.toml
@@ -1,0 +1,38 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[540a3d51-e7a6-47a5-92a3-4ad1838f0bfd]
+description = "zero steps for one"
+
+[3d76a0a6-ea84-444a-821a-f7857c2c1859]
+description = "divide if even"
+
+[754dea81-123c-429e-b8bc-db20b05a87b9]
+description = "even and odd steps"
+
+[ecfd0210-6f85-44f6-8280-f65534892ff6]
+description = "large number of even and odd steps"
+
+[7d4750e6-def9-4b86-aec7-9f7eb44f95a3]
+description = "zero is an error"
+include = false
+
+[2187673d-77d6-4543-975e-66df6c50e2da]
+description = "zero is an error"
+reimplements = "7d4750e6-def9-4b86-aec7-9f7eb44f95a3"
+
+[c6c795bf-a288-45e9-86a1-841359ad426d]
+description = "negative value is an error"
+include = false
+
+[ec11f479-56bc-47fd-a434-bcd7a31a7a2e]
+description = "negative value is an error"
+reimplements = "c6c795bf-a288-45e9-86a1-841359ad426d"

--- a/exercises/practice/collatz-conjecture/collatz-conjecture-test.el
+++ b/exercises/practice/collatz-conjecture/collatz-conjecture-test.el
@@ -1,0 +1,41 @@
+;;; collatz-conjecture-test.el --- Tests for Collatz Conjecture (exercism)  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;;; Code:
+
+(load-file "collatz-conjecture.el")
+(declare-function steps "collatz-conjecture.el" (number))
+
+
+(ert-deftest zero-steps-for-one ()
+  (should (equal 0 (steps 1))))
+
+
+(ert-deftest divide-if-even ()
+  (should (equal 4 (steps 16))))
+
+
+(ert-deftest even-and-odd-steps ()
+  (should (equal 9 (steps 12))))
+
+
+(ert-deftest large-number-of-even-and-odd-steps ()
+  (should (equal 152 (steps 1000000))))
+
+
+(ert-deftest zero-is-an-error ()
+  (should
+   (equal
+    (should-error (steps 0))
+    '(error . ("Only positive integers are allowed")))))
+
+
+(ert-deftest negative-value-is-an-error ()
+  (should
+   (equal
+    (should-error (steps -15))
+    '(error . ("Only positive integers are allowed")))))
+
+(provide 'collatz-conjecture-test)
+;;; collatz-conjecture-test.el ends here

--- a/exercises/practice/collatz-conjecture/collatz-conjecture-test.el
+++ b/exercises/practice/collatz-conjecture/collatz-conjecture-test.el
@@ -25,17 +25,11 @@
 
 
 (ert-deftest zero-is-an-error ()
-  (should
-   (equal
-    (should-error (steps 0))
-    '(error . ("Only positive integers are allowed")))))
+  (should-error (steps 0)))
 
 
 (ert-deftest negative-value-is-an-error ()
-  (should
-   (equal
-    (should-error (steps -15))
-    '(error . ("Only positive integers are allowed")))))
+  (should-error (steps -15)))
 
 (provide 'collatz-conjecture-test)
 ;;; collatz-conjecture-test.el ends here

--- a/exercises/practice/collatz-conjecture/collatz-conjecture.el
+++ b/exercises/practice/collatz-conjecture/collatz-conjecture.el
@@ -1,0 +1,12 @@
+;;; collatz-conjecture.el --- Collatz Conjecture (exercism)  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;;; Code:
+
+(defun steps (number)
+  "Count the steps to reach 1 using the Collatz conjecture."
+  (error "Delete this S-Expression and write your own implementation"))
+
+(provide 'collatz-conjecture)
+;;; collatz-conjecture.el ends here


### PR DESCRIPTION
Function and argument names, and test cases, are taken from
https://github.com/exercism/problem-specifications/blob/main/exercises/collatz-conjecture/canonical-data.json
