### PR TITLE
feat: Add exercise Triangle (closes #312)

### DIFF
--- a/config.json
+++ b/config.json
@@ -377,6 +377,17 @@
         ]
       },
       {
+        "slug": "triangle",
+        "name": "Triangle",
+        "uuid": "df52be2e-8709-4da5-a8c2-03a2fd137993",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2,
+        "topics": [
+          "control_flow_conditionals"
+        ]
+      },
+      {
         "slug": "trinary",
         "name": "Trinary",
         "uuid": "c5239cf6-c5a3-4d81-a4d9-504c292ff11e",

--- a/exercises/practice/triangle/.docs/instructions.md
+++ b/exercises/practice/triangle/.docs/instructions.md
@@ -1,0 +1,29 @@
+# Instructions
+
+Determine if a triangle is equilateral, isosceles, or scalene.
+
+An _equilateral_ triangle has all three sides the same length.
+
+An _isosceles_ triangle has at least two sides the same length.
+(It is sometimes specified as having exactly two sides the same length, but for the purposes of this exercise we'll say at least two.)
+
+A _scalene_ triangle has all sides of different lengths.
+
+## Note
+
+For a shape to be a triangle at all, all sides have to be of length > 0, and the sum of the lengths of any two sides must be greater than or equal to the length of the third side.
+
+In equations:
+
+Let `a`, `b`, and `c` be sides of the triangle.
+Then all three of the following expressions must be true:
+
+```text
+a + b ≥ c
+b + c ≥ a
+a + c ≥ b
+```
+
+See [Triangle Inequality][triangle-inequality]
+
+[triangle-inequality]: https://en.wikipedia.org/wiki/Triangle_inequality

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "keiravillekode"
+  ],
+  "files": {
+    "solution": [
+      "triangle.el"
+    ],
+    "test": [
+      "triangle-test.el"
+    ],
+    "example": [
+      ".meta/example.el"
+    ]
+  },
+  "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
+  "source": "The Ruby Koans triangle project, parts 1 & 2",
+  "source_url": "https://web.archive.org/web/20220831105330/http://rubykoans.com"
+}

--- a/exercises/practice/triangle/.meta/example.el
+++ b/exercises/practice/triangle/.meta/example.el
@@ -1,0 +1,50 @@
+;;; triangle.el --- Triangle (exercism)  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;;; Code:
+
+
+(defun validp (sides)
+  "Return non-nil if sides are positive and triangle inequality is satisfied"
+  (let ((a (car sides))
+        (b (cadr sides))
+        (c (caddr sides)))
+    (and
+      (< 0 a)
+      (< 0 b)
+      (< 0 c)
+      (<= a (+ b c))
+      (<= b (+ a c))
+      (<= c (+ a b)))))
+
+(defun equilateralp (sides)
+  "Return non-nil if sides represent a valid equilateral triangle"
+  (let ((a (car sides))
+        (b (cadr sides))
+        (c (caddr sides)))
+    (and
+      (validp sides)
+      (= a b)
+      (= a c))))
+
+(defun isoscelesp (sides)
+  "Return non-nil if sides represent a valid isosceles triangle"
+  (let ((a (car sides))
+        (b (cadr sides))
+        (c (caddr sides)))
+    (and
+      (validp sides)
+      (or
+        (= a b)
+        (= a c)
+        (= b c)))))
+
+(defun scalenep (sides)
+  "Return non-nil if sides represent a valid scalene triangle"
+  (and
+    (validp sides)
+    (not (isoscelesp sides))))
+
+(provide 'triangle)
+;;; triangle.el ends here

--- a/exercises/practice/triangle/.meta/tests.toml
+++ b/exercises/practice/triangle/.meta/tests.toml
@@ -1,0 +1,73 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[8b2c43ac-7257-43f9-b552-7631a91988af]
+description = "equilateral triangle -> all sides are equal"
+
+[33eb6f87-0498-4ccf-9573-7f8c3ce92b7b]
+description = "equilateral triangle -> any side is unequal"
+
+[c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87]
+description = "equilateral triangle -> no sides are equal"
+
+[16e8ceb0-eadb-46d1-b892-c50327479251]
+description = "equilateral triangle -> all zero sides is not a triangle"
+
+[3022f537-b8e5-4cc1-8f12-fd775827a00c]
+description = "equilateral triangle -> sides may be floats"
+
+[cbc612dc-d75a-4c1c-87fc-e2d5edd70b71]
+description = "isosceles triangle -> last two sides are equal"
+
+[e388ce93-f25e-4daf-b977-4b7ede992217]
+description = "isosceles triangle -> first two sides are equal"
+
+[d2080b79-4523-4c3f-9d42-2da6e81ab30f]
+description = "isosceles triangle -> first and last sides are equal"
+
+[8d71e185-2bd7-4841-b7e1-71689a5491d8]
+description = "isosceles triangle -> equilateral triangles are also isosceles"
+
+[840ed5f8-366f-43c5-ac69-8f05e6f10bbb]
+description = "isosceles triangle -> no sides are equal"
+
+[2eba0cfb-6c65-4c40-8146-30b608905eae]
+description = "isosceles triangle -> first triangle inequality violation"
+
+[278469cb-ac6b-41f0-81d4-66d9b828f8ac]
+description = "isosceles triangle -> second triangle inequality violation"
+
+[90efb0c7-72bb-4514-b320-3a3892e278ff]
+description = "isosceles triangle -> third triangle inequality violation"
+
+[adb4ee20-532f-43dc-8d31-e9271b7ef2bc]
+description = "isosceles triangle -> sides may be floats"
+
+[e8b5f09c-ec2e-47c1-abec-f35095733afb]
+description = "scalene triangle -> no sides are equal"
+
+[2510001f-b44d-4d18-9872-2303e7977dc1]
+description = "scalene triangle -> all sides are equal"
+
+[c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e]
+description = "scalene triangle -> first and second sides are equal"
+
+[3da23a91-a166-419a-9abf-baf4868fd985]
+description = "scalene triangle -> first and third sides are equal"
+
+[b6a75d98-1fef-4c42-8e9a-9db854ba0a4d]
+description = "scalene triangle -> second and third sides are equal"
+
+[70ad5154-0033-48b7-af2c-b8d739cd9fdc]
+description = "scalene triangle -> may not violate triangle inequality"
+
+[26d9d59d-f8f1-40d3-ad58-ae4d54123d7d]
+description = "scalene triangle -> sides may be floats"

--- a/exercises/practice/triangle/triangle-test.el
+++ b/exercises/practice/triangle/triangle-test.el
@@ -15,15 +15,15 @@
 
 
 (ert-deftest any-side-is-unequal ()
-  (should (not (equilateralp '(2 3 2)))))
+  (should-not (equilateralp '(2 3 2))))
 
 
 (ert-deftest no-sides-are-equal ()
-  (should (not (equilateralp '(5 4 6)))))
+  (should-not (equilateralp '(5 4 6))))
 
 
 (ert-deftest all-zero-sides-is-not-a-triangle ()
-  (should (not (equilateralp '(0 0 0)))))
+  (should-not (equilateralp '(0 0 0))))
 
 
 (ert-deftest sides-may-be-floats ()
@@ -47,19 +47,19 @@
 
 
 (ert-deftest no-sides-are-equal ()
-  (should (not (isoscelesp '(2 3 4)))))
+  (should-not (isoscelesp '(2 3 4))))
 
 
 (ert-deftest first-triangle-inequality-violation ()
-  (should (not (isoscelesp '(1 1 3)))))
+  (should-not (isoscelesp '(1 1 3))))
 
 
 (ert-deftest second-triangle-inequality-violation ()
-  (should (not (isoscelesp '(1 3 1)))))
+  (should-not (isoscelesp '(1 3 1))))
 
 
 (ert-deftest third-triangle-inequality-violation ()
-  (should (not (isoscelesp '(3 1 1)))))
+  (should-not (isoscelesp '(3 1 1))))
 
 
 (ert-deftest sides-may-be-floats ()
@@ -71,23 +71,23 @@
 
 
 (ert-deftest all-sides-are-equal ()
-  (should (not (scalenep '(4 4 4)))))
+  (should-not (scalenep '(4 4 4))))
 
 
 (ert-deftest first-and-second-sides-are-equal ()
-  (should (not (scalenep '(4 4 3)))))
+  (should-not (scalenep '(4 4 3))))
 
 
 (ert-deftest first-and-third-sides-are-equal ()
-  (should (not (scalenep '(3 4 3)))))
+  (should-not (scalenep '(3 4 3))))
 
 
 (ert-deftest second-and-third-sides-are-equal ()
-  (should (not (scalenep '(4 3 3)))))
+  (should-not (scalenep '(4 3 3))))
 
 
 (ert-deftest may-not-violate-triangle-inequality ()
-  (should (not (scalenep '(7 3 2)))))
+  (should-not (scalenep '(7 3 2))))
 
 
 (ert-deftest sides-may-be-floats ()

--- a/exercises/practice/triangle/triangle-test.el
+++ b/exercises/practice/triangle/triangle-test.el
@@ -1,0 +1,97 @@
+;;; triangle-test.el --- Tests for Triangle (exercism)  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;;; Code:
+
+(load-file "triangle.el")
+(declare-function equilateralp "triangle.el" (sides))
+(declare-function isoscelesp "triangle.el" (sides))
+(declare-function scalenep "triangle.el" (sides))
+
+
+(ert-deftest all-sides-are-equal ()
+  (should (equilateralp '(2 2 2))))
+
+
+(ert-deftest any-side-is-unequal ()
+  (should (not (equilateralp '(2 3 2)))))
+
+
+(ert-deftest no-sides-are-equal ()
+  (should (not (equilateralp '(5 4 6)))))
+
+
+(ert-deftest all-zero-sides-is-not-a-triangle ()
+  (should (not (equilateralp '(0 0 0)))))
+
+
+(ert-deftest sides-may-be-floats ()
+  (should (equilateralp '(0.5 0.5 0.5))))
+
+
+(ert-deftest last-two-sides-are-equal ()
+  (should (isoscelesp '(3 4 4))))
+
+
+(ert-deftest first-two-sides-are-equal ()
+  (should (isoscelesp '(4 4 3))))
+
+
+(ert-deftest first-and-last-sides-are-equal ()
+  (should (isoscelesp '(4 3 4))))
+
+
+(ert-deftest equilateral-triangles-are-also-isosceles ()
+  (should (isoscelesp '(4 4 4))))
+
+
+(ert-deftest no-sides-are-equal ()
+  (should (not (isoscelesp '(2 3 4)))))
+
+
+(ert-deftest first-triangle-inequality-violation ()
+  (should (not (isoscelesp '(1 1 3)))))
+
+
+(ert-deftest second-triangle-inequality-violation ()
+  (should (not (isoscelesp '(1 3 1)))))
+
+
+(ert-deftest third-triangle-inequality-violation ()
+  (should (not (isoscelesp '(3 1 1)))))
+
+
+(ert-deftest sides-may-be-floats ()
+  (should (isoscelesp '(0.5 0.4 0.5))))
+
+
+(ert-deftest no-sides-are-equal ()
+  (should (scalenep '(5 4 6))))
+
+
+(ert-deftest all-sides-are-equal ()
+  (should (not (scalenep '(4 4 4)))))
+
+
+(ert-deftest first-and-second-sides-are-equal ()
+  (should (not (scalenep '(4 4 3)))))
+
+
+(ert-deftest first-and-third-sides-are-equal ()
+  (should (not (scalenep '(3 4 3)))))
+
+
+(ert-deftest second-and-third-sides-are-equal ()
+  (should (not (scalenep '(4 3 3)))))
+
+
+(ert-deftest may-not-violate-triangle-inequality ()
+  (should (not (scalenep '(7 3 2)))))
+
+
+(ert-deftest sides-may-be-floats ()
+  (should (scalenep '(0.5 0.4 0.6))))
+
+(provide 'triangle-test)
+;;; triangle-test.el ends here

--- a/exercises/practice/triangle/triangle.el
+++ b/exercises/practice/triangle/triangle.el
@@ -1,0 +1,18 @@
+;;; triangle.el --- Triangle (exercism)  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;;; Code:
+
+
+(defun equilateralp (sides)
+  (error "Delete this S-Expression and write your own implementation"))
+
+(defun isoscelesp (sides)
+  (error "Delete this S-Expression and write your own implementation"))
+
+(defun scalenep (sides)
+  (error "Delete this S-Expression and write your own implementation"))
+
+(provide 'triangle)
+;;; triangle.el ends here


### PR DESCRIPTION
Function names have a "p" suffix, consistent with naming conventions for predicates.
In all other respects, function and argument names, and test cases, are taken from
https://github.com/exercism/problem-specifications/blob/main/exercises/triangle/canonical-data.json
