### PR TITLE
binary-search: use equal for all numeric test comparisons

### DIFF
--- a/exercises/practice/binary-search/binary-search-test.el
+++ b/exercises/practice/binary-search/binary-search-test.el
@@ -10,29 +10,29 @@
 
 
 (ert-deftest finds-a-value-in-an-array-with-one-element ()
-  (should (= (find-binary [6] 6) 0)))
+  (should (equal (find-binary [6] 6) 0)))
 
 
 (ert-deftest finds-a-value-in-the-middle-of-an-array ()
-  (should (= (find-binary [1 3 4 6 8 9 11] 6) 3)))
+  (should (equal (find-binary [1 3 4 6 8 9 11] 6) 3)))
 
 
 (ert-deftest finds-a-value-at-the-beginning-of-an-array ()
-  (should (= (find-binary [1 3 4 6 8 9 11] 1) 0)))
+  (should (equal (find-binary [1 3 4 6 8 9 11] 1) 0)))
 
 
 (ert-deftest finds-a-value-at-the-end-of-an-array ()
-  (should (= (find-binary [1 3 4 6 8 9 11] 11) 6)))
+  (should (equal (find-binary [1 3 4 6 8 9 11] 11) 6)))
 
 
 (ert-deftest finds-a-value-in-an-array-of-odd-length ()
   (should
-   (= (find-binary [1 3 5 8 13 21 34 55 89 144 233 377 634] 144) 9)))
+   (equal (find-binary [1 3 5 8 13 21 34 55 89 144 233 377 634] 144) 9)))
 
 
 (ert-deftest finds-a-value-in-an-array-of-even-length ()
   (should
-   (= (find-binary [1 3 5 8 13 21 34 55 89 144 233 377] 21) 5)))
+   (equal (find-binary [1 3 5 8 13 21 34 55 89 144 233 377] 21) 5)))
 
 
 (ert-deftest identifies-that-a-value-is-not-included-in-the-array ()


### PR DESCRIPTION
This is more of a question about consistency within a test suite and across all the exercises than anything else.  I'll also preface this with noting that I rarely write elisp.  If there are rules or best practices for what follows regarding equality other than the docstrings, I don't know about them.

If a beginner looks at the tests, they might be confused that some use `=` and others use `equal` for comparison.  They may then decide to discover that there's `=/eq/eql/equal/char-equal/...` and so on.  Aside from that, if I write a function that I know will only ever return integers, I'll use `=`.  If it could also return nil, I'd blanket use `equal` (or possibly even `eql` instead.

Are the other exercises in the track consistent with comparisons?