### PR TITLE
Update path for example.el in track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -21,7 +21,7 @@
   "files": {
     "solution": ["%{kebab_slug}.el"],
     "test": ["%{kebab_slug}-test.el"],
-    "example": ["example.el"],
+    "example": [".meta/example.el"],
     "exemplar": [".meta/exemplar.el"]
   },
   "exercises": {


### PR DESCRIPTION
I noticed the `configlet sync --metadata` was writing the wrong relative path for `example.el` in an exercise's config.json.