### PR TITLE
Update generator to use configlet create

### DIFF
--- a/bin/generate_practice_exercise
+++ b/bin/generate_practice_exercise
@@ -35,16 +35,7 @@ echo "Fetching latest version of configlet..."
 
 # Preparing config.json
 echo "Adding instructions and configuration files..."
-UUID=$(bin/configlet uuid)
-jq --arg slug "$SLUG" --arg uuid "$UUID" \
-    '.exercises.practice += [{slug: $slug, name: "TODO", uuid: $uuid, practices: [], prerequisites: [], difficulty: 5}]' \
-    config.json > config.json.tmp
-# jq always rounds whole numbers, but average_run_time needs to be a float
-sed -i 's/"average_run_time": \([[:digit:]]\+\)$/"average_run_time": 2.0/' config.json.tmp
-mv config.json.tmp config.json
-
-# Create instructions and config files
-./bin/configlet sync --update --yes --docs --filepaths --metadata --exercise "$SLUG"
+./bin/configlet create --practice-exercise "$SLUG"
 
 pushd tools
 emacs -batch -l install-packages.el -l practice-exercise-generator.el --eval "(exercism/generate-practice-exercise \"$SLUG\")"


### PR DESCRIPTION
@exercism/emacs-lisp, configlet create --practice-exercise <slug> now creates the config entry for the slug as well as sync the problem-specifications metadata / docs. Exercism stopped using floats for the average run time a while ago so that line's not needed either.