### PR TITLE
Update example.el relative path

### DIFF
--- a/config.json
+++ b/config.json
@@ -21,7 +21,7 @@
   "files": {
     "solution": ["%{kebab_slug}.el"],
     "test": ["%{kebab_slug}-test.el"],
-    "example": ["example.el"],
+    "example": [".meta/example.el"],
     "exemplar": [".meta/exemplar.el"]
   },
   "exercises": {


### PR DESCRIPTION
@exercism/emacs-lisp, this is related to #348, but the example.el file path is incorrect in the track config so new exercises will have it in the wrong location. Then the exercise's config file needs to be updated manually.