### PR TITLE
Sync roman-numerals tests

### DIFF
--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -1,5 +1,7 @@
 {
-  "authors": [],
+  "authors": [
+    "cpaulbond"
+  ],
   "contributors": [
     "bakhti",
     "canweriotnow",

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -30,6 +30,9 @@ description = "6 is VI"
 [ff3fb08c-4917-4aab-9f4e-d663491d083d]
 description = "9 is IX"
 
+[6d1d82d5-bf3e-48af-9139-87d7165ed509]
+description = "16 is XVI"
+
 [2bda64ca-7d28-4c56-b08d-16ce65716cf6]
 description = "27 is XXVII"
 
@@ -42,6 +45,9 @@ description = "49 is XLIX"
 [d5b283d4-455d-4e68-aacf-add6c4b51915]
 description = "59 is LIX"
 
+[4465ffd5-34dc-44f3-ada5-56f5007b6dad]
+description = "66 is LXVI"
+
 [46b46e5b-24da-4180-bfe2-2ef30b39d0d0]
 description = "93 is XCIII"
 
@@ -51,11 +57,17 @@ description = "141 is CXLI"
 [267f0207-3c55-459a-b81d-67cec7a46ed9]
 description = "163 is CLXIII"
 
+[902ad132-0b4d-40e3-8597-ba5ed611dd8d]
+description = "166 is CLXVI"
+
 [cdb06885-4485-4d71-8bfb-c9d0f496b404]
 description = "402 is CDII"
 
 [6b71841d-13b2-46b4-ba97-dec28133ea80]
 description = "575 is DLXXV"
+
+[dacb84b9-ea1c-4a61-acbb-ce6b36674906]
+description = "666 is DCLXVI"
 
 [432de891-7fd6-4748-a7f6-156082eeca2f]
 description = "911 is CMXI"
@@ -63,26 +75,17 @@ description = "911 is CMXI"
 [e6de6d24-f668-41c0-88d7-889c0254d173]
 description = "1024 is MXXIV"
 
-[bb550038-d4eb-4be2-a9ce-f21961ac3bc6]
-description = "3000 is MMM"
-
-[6d1d82d5-bf3e-48af-9139-87d7165ed509]
-description = "16 is XVI"
-
-[4465ffd5-34dc-44f3-ada5-56f5007b6dad]
-description = "66 is LXVI"
-
-[902ad132-0b4d-40e3-8597-ba5ed611dd8d]
-description = "166 is CLXVI"
-
-[dacb84b9-ea1c-4a61-acbb-ce6b36674906]
-description = "666 is DCLXVI"
-
 [efbe1d6a-9f98-4eb5-82bc-72753e3ac328]
 description = "1666 is MDCLXVI"
 
+[bb550038-d4eb-4be2-a9ce-f21961ac3bc6]
+description = "3000 is MMM"
+
 [3bc4b41c-c2e6-49d9-9142-420691504336]
 description = "3001 is MMMI"
+
+[2f89cad7-73f6-4d1b-857b-0ef531f68b7e]
+description = "3888 is MMMDCCCLXXXVIII"
 
 [4e18e96b-5fbb-43df-a91b-9cb511fe0856]
 description = "3999 is MMMCMXCIX"

--- a/exercises/practice/roman-numerals/roman-numerals-test.el
+++ b/exercises/practice/roman-numerals/roman-numerals-test.el
@@ -4,83 +4,118 @@
 
 ;;; Code:
 
+
 (load-file "roman-numerals.el")
 (declare-function to-roman "roman-numerals.el" (value))
 
-(ert-deftest to-roman-1 ()
-  (should (equal (to-roman 1) "I")))
 
-(ert-deftest to-roman-2 ()
-  (should (equal (to-roman 2) "II")))
+(ert-deftest 1-is-I ()
+  (should (string= "I" (to-roman 1))))
 
-(ert-deftest to-roman-3 ()
-  (should (equal (to-roman 3) "III")))
 
-(ert-deftest to-roman-4 ()
-  (should (equal (to-roman 4) "IV")))
+(ert-deftest 2-is-II ()
+  (should (string= "II" (to-roman 2))))
 
-(ert-deftest to-roman-5 ()
-  (should (equal (to-roman 5) "V")))
 
-(ert-deftest to-roman-6 ()
-  (should (equal (to-roman 6) "VI")))
+(ert-deftest 3-is-III ()
+  (should (string= "III" (to-roman 3))))
 
-(ert-deftest to-roman-9 ()
-  (should (equal (to-roman 9) "IX")))
 
-(ert-deftest to-roman-16 ()
-  (should (equal (to-roman 16) "XVI")))
+(ert-deftest 4-is-IV ()
+  (should (string= "IV" (to-roman 4))))
 
-(ert-deftest to-roman-27 ()
-  (should (equal (to-roman 27) "XXVII")))
 
-(ert-deftest to-roman-48 ()
-  (should (equal (to-roman 48) "XLVIII")))
+(ert-deftest 5-is-V ()
+  (should (string= "V" (to-roman 5))))
 
-(ert-deftest to-roman-59 ()
-  (should (equal (to-roman 59) "LIX")))
 
-(ert-deftest to-roman-66 ()
-  (should (equal (to-roman 66) "LXVI")))
+(ert-deftest 6-is-VI ()
+  (should (string= "VI" (to-roman 6))))
 
-(ert-deftest to-roman-93 ()
-  (should (equal (to-roman 93) "XCIII")))
 
-(ert-deftest to-roman-141 ()
-  (should (equal (to-roman 141) "CXLI")))
+(ert-deftest 9-is-IX ()
+  (should (string= "IX" (to-roman 9))))
 
-(ert-deftest to-roman-163 ()
-  (should (equal (to-roman 163) "CLXIII")))
 
-(ert-deftest to-roman-166 ()
-  (should (equal (to-roman 166) "CLXVI")))
+(ert-deftest 16-is-XVI ()
+  (should (string= "XVI" (to-roman 16))))
 
-(ert-deftest to-roman-402 ()
-  (should (equal (to-roman 402) "CDII")))
 
-(ert-deftest to-roman-575 ()
-  (should (equal (to-roman 575) "DLXXV")))
+(ert-deftest 27-is-XXVII ()
+  (should (string= "XXVII" (to-roman 27))))
 
-(ert-deftest to-roman-666 ()
-  (should (equal (to-roman 666) "DCLXVI")))
 
-(ert-deftest to-roman-911 ()
-  (should (equal (to-roman 911) "CMXI")))
+(ert-deftest 48-is-XLVIII ()
+  (should (string= "XLVIII" (to-roman 48))))
 
-(ert-deftest to-roman-1024 ()
-  (should (equal (to-roman 1024) "MXXIV")))
 
-(ert-deftest to-roman-1666 ()
-  (should (equal (to-roman 1666) "MDCLXVI")))
+(ert-deftest 49-is-XLIX ()
+  (should (string= "XLIX" (to-roman 49))))
 
-(ert-deftest to-roman-3000 ()
-  (should (equal (to-roman 3000) "MMM")))
 
-(ert-deftest to-roman-3001 ()
-  (should (equal (to-roman 3001) "MMMI")))
+(ert-deftest 59-is-LIX ()
+  (should (string= "LIX" (to-roman 59))))
 
-(ert-deftest to-roman-3999 ()
-  (should (equal (to-roman 3999) "MMMCMXCIX")))
 
-(provide 'roman-numerals)
+(ert-deftest 66-is-LXVI ()
+  (should (string= "LXVI" (to-roman 66))))
+
+
+(ert-deftest 93-is-XCIII ()
+  (should (string= "XCIII" (to-roman 93))))
+
+
+(ert-deftest 141-is-CXLI ()
+  (should (string= "CXLI" (to-roman 141))))
+
+
+(ert-deftest 163-is-CLXIII ()
+  (should (string= "CLXIII" (to-roman 163))))
+
+
+(ert-deftest 166-is-CLXVI ()
+  (should (string= (to-roman 166) "CLXVI")))
+
+
+(ert-deftest 402-is-CDII ()
+  (should (string= "CDII" (to-roman 402))))
+
+
+(ert-deftest 575-is-DLXXV ()
+  (should (string= "DLXXV" (to-roman 575))))
+
+
+(ert-deftest 666-is-DCLXVI ()
+  (should (string= "DCLXVI" (to-roman 666))))
+
+
+(ert-deftest 911-is-CMXI ()
+  (should (string= "CMXI" (to-roman 911))))
+
+
+(ert-deftest 1024-is-MXXIV ()
+  (should (string= "MXXIV" (to-roman 1024))))
+
+
+(ert-deftest 1666-is-MDCLXVI ()
+  (should (string= "MDCLXVI" (to-roman 1666))))
+
+
+(ert-deftest 3000-is-MMM ()
+  (should (string= "MMM" (to-roman 3000))))
+
+
+(ert-deftest 3001-is-MMMI ()
+  (should (string= "MMMI" (to-roman 3001))))
+
+
+(ert-deftest 3888-is-MMMDCCCLXXXVIII ()
+  (should (string= "MMMDCCCLXXXVIII" (to-roman 3888))))
+
+
+(ert-deftest 3999-is-MMMCMXCIX ()
+  (should (string= "MMMCMXCIX" (to-roman 3999 ))))
+
+
+(provide 'roman-numerals-test)
 ;;; roman-numerals-test.el ends here

--- a/exercises/practice/roman-numerals/roman-numerals.el
+++ b/exercises/practice/roman-numerals/roman-numerals.el
@@ -2,9 +2,12 @@
 
 ;;; Commentary:
 
-(defun to-roman (value)
 ;;; Code:
-)
+
+
+(defun to-roman (value)
+  (error "Delete this S-Expression and write your own implementation"))
+
 
 (provide 'roman-numerals)
 ;;; roman-numerals.el ends here


### PR DESCRIPTION
Related to #229.

I swapped out `equal` for `string=`, updated the test names, and added the latest test for 3999. I also reformatted the stub to resemble what the exercise generator would make nowadays. Finally, I looked up the original author to give them proper credit.