### PR TITLE
practice-exercise-generator: Don't include commas in test names

### DIFF
--- a/tools/practice-exercise-generator.el
+++ b/tools/practice-exercise-generator.el
@@ -171,7 +171,9 @@ Each hash-table has the keys:
                       ("test-name"
                        (string-inflection-kebab-case-function
                         (replace-regexp-in-string
-                         "[ |_]" "-" (gethash "description" elem))))
+                         "," ""
+                         (replace-regexp-in-string
+                          "[ |_]" "-" (gethash "description" elem)))))
                       ("uuid" (gethash "uuid" elem))
                       ("reimplements" (gethash "reimplements" elem))
                       ("function-under-test"


### PR DESCRIPTION
fixes #419