### PR TITLE
Fix flaky configlet-sync job

### DIFF
--- a/.github/workflows/configlet-sync.yml
+++ b/.github/workflows/configlet-sync.yml
@@ -39,4 +39,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           filename: .github/configlet-sync-issue.md
-          update_existing: true


### PR DESCRIPTION
The job sometimes fails because we're hitting a rate limit. Removing `update_existing: true` seems to the main culprit for hitting the rate limit.

See https://github.com/JasonEtco/create-an-issue/issues/142#issuecomment-2066826259

works on #359