### PR TITLE
Rename two exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -481,7 +481,7 @@
       },
       {
         "slug": "two-fer",
-        "name": "Two Fer",
+        "name": "Two-Fer",
         "uuid": "36e5dc3a-2122-484a-ae82-beb7b813e2cd",
         "practices": [],
         "prerequisites": [],
@@ -782,7 +782,7 @@
       },
       {
         "slug": "isbn-verifier",
-        "name": "Isbn Verifier",
+        "name": "ISBN Verifier",
         "uuid": "b0cbc3b5-1d6c-40b8-bdd1-5ba9089024aa",
         "practices": [],
         "prerequisites": [],


### PR DESCRIPTION
Now all practice exercises have names consistent with problem-specifications metadata

https://github.com/exercism/problem-specifications/blob/main/exercises/isbn-verifier/metadata.toml

https://github.com/exercism/problem-specifications/blob/main/exercises/two-fer/metadata.toml

[no important files changed]