### PR TITLE
Added a Emacs Lisp track-spepcific instruction to "Phone Number" (#465)

### DIFF
--- a/exercises/practice/phone-number/.docs/instructions.append.md
+++ b/exercises/practice/phone-number/.docs/instructions.append.md
@@ -1,0 +1,7 @@
+# Instructions Append
+
+In addition to the function, _numbers_, that cleans up user-entered phone numbers, you need to write two more functions, _area-code_ and _pprint_ in the Emacs Lisp track. Both of the extra functions take the user-entered phone number as their inputs. The first function _area-code_ extracts the area code from the input, while the second function _pprint_ transforms the input to a string in the format of 
+```
+(NXX) NXX-XXXX
+```
+where `N` and `X` are as described above.

--- a/exercises/practice/phone-number/.docs/instructions.append.md
+++ b/exercises/practice/phone-number/.docs/instructions.append.md
@@ -1,6 +1,10 @@
 # Instructions Append
 
-In addition to the function, _numbers_, that cleans up user-entered phone numbers, you need to write two more functions, _area-code_ and _pprint_ in the Emacs Lisp track. Both of the extra functions take the user-entered phone number as their inputs. The first function _area-code_ extracts the area code from the input, while the second function _pprint_ transforms the input to a string in the format of 
+In addition to the function, _numbers_, that cleans up phone numbers, you need to write two more functions, _area-code_ and _pprint_ in the Emacs Lisp track. 
+
+Each of the extra functions takes the phone number as its only parameter.
+
+The first function _area-code_ extracts the area code from the input, while the second function _pprint_ transforms the input to a string in the format of 
 ```
 (NXX) NXX-XXXX
 ```


### PR DESCRIPTION
Because the instruction of "Phone Number" had no description about two functions, _area-code_ and _pprint_, which are only required in the Emacs Lisp track, I added their description.