### PR TITLE
list-ops: Make headline for instructions append show up in UI

### DIFF
--- a/exercises/practice/list-ops/.docs/instructions.append.md
+++ b/exercises/practice/list-ops/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-# Emacs Lisp Track specific functions
+## Emacs Lisp track specific functions
 
 * `list-empty-p` (*given a list, return if the list is empty*)
 * `list-sum` (*given a list of numbers, return the sum of all elements*)


### PR DESCRIPTION
- changes headline level for instructions append to make it show  up in the web UI