### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/dominoes/.docs/instructions.append.md
+++ b/exercises/practice/dominoes/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 Each stone is represented as a dotted pair.

--- a/exercises/practice/flatten-array/.docs/instructions.append.md
+++ b/exercises/practice/flatten-array/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 The input and output are represented as lists.

--- a/exercises/practice/list-ops/.docs/instructions.append.md
+++ b/exercises/practice/list-ops/.docs/instructions.append.md
@@ -1,5 +1,6 @@
+# Instructions append
+
 ## Emacs Lisp track specific functions
 
 * `list-empty-p` (*given a list, return if the list is empty*)
 * `list-sum` (*given a list of numbers, return the sum of all elements*)
-

--- a/exercises/practice/phone-number/.docs/instructions.append.md
+++ b/exercises/practice/phone-number/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions Append
 
+## Implementation
+
 In addition to the function, _numbers_, that cleans up phone numbers, you need to write two more functions, _area-code_ and _pprint_ in the Emacs Lisp track. 
 
 Each of the extra functions takes the phone number as its only parameter.

--- a/exercises/practice/rational-numbers/.docs/instructions.append.md
+++ b/exercises/practice/rational-numbers/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 Each rational number is represented as a dotted pair.

--- a/exercises/practice/resistor-color-trio/.docs/instructions.append.md
+++ b/exercises/practice/resistor-color-trio/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 An input of `"orange", "orange", "green"` should return:
 
 > "3.3 megaohms"


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.